### PR TITLE
testpypi upload - v 0.10.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 0.9.9
-commit = False
+commit = True
 tag = False
 
 [bumpversion:file:docs/conf.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.9
+current_version = 0.10.0
 commit = True
 tag = False
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ sys.path.append("../")
 project = "iniabu"
 author = "Reto Trappitsch"
 copyright = "2020, {}".format(author)
-version = "0.9.9"
+version = "0.10.0"
 release = version
 
 

--- a/iniabu/__init__.py
+++ b/iniabu/__init__.py
@@ -7,7 +7,7 @@ ini = IniAbu()
 
 
 # Package information
-__version__ = "0.9.9"
+__version__ = "0.10.0"
 
 __title__ = "iniabu"
 __description__ = (


### PR DESCRIPTION
Create a testpypi upload for direct installation and testing from testpypi.
Bumped version to 0.10.0 - all future tests will be in 0.10.x naming scheme.

no changes that change codebase
