### PR TITLE
Add capability to return element and isotope masses

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -71,8 +71,8 @@ i.e., as not a number.
 Usage
 -----
 
-Importing the module:
-~~~~~~~~~~~~~~~~~~~~~
+Importing the module
+~~~~~~~~~~~~~~~~~~~~
 
 Once installed,
 you can simply import the package
@@ -103,8 +103,8 @@ the following import could be used:
     >>> db2 = iniabu.IniAbu(database="asplund09")
 
 
-Loading a data base:
-~~~~~~~~~~~~~~~~~~~~
+Loading a data base
+~~~~~~~~~~~~~~~~~~~
 
 Switching the data base from a given instance `ini`
 can be easily accomplished.
@@ -118,8 +118,8 @@ by calling:
 
 
 
-Putting the solar abundances into logarithmic mode:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Putting the solar abundances into logarithmic mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Isotopic abundances can easily be switched between
 linear and logarithmic units.
@@ -160,8 +160,8 @@ the following command can be used:
 By default,
 linear values are used.
 
-Element and isotope properties:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Element and isotope properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Properties of an element are independent from the loaded database
 and are taken from the
 `NIST database <https://www.nist.gov/pml/atomic-weights-and-isotopic-compositions-relative-atomic-masses>`_.
@@ -185,6 +185,10 @@ can be loaded into a variable as following:
 The following properties can now be queried
 from the element:
 
+- The mass of the element,
+  calculated using the isotope masses
+  and the currently loaded abundances,
+  using `mass`.
 - The solar abundance of the element itself using `solar_abundance`,
   normed as discussed above
 - The mass number of its (stable) isotopes using `isotopes_a`
@@ -203,8 +207,8 @@ one could run the following statement:
 
 
 
-Querying an isotope:
-~~~~~~~~~~~~~~~~~~~~
+Querying an isotope
+~~~~~~~~~~~~~~~~~~~
 
 To query an isotope's properties
 with respect to teh solar abundance,
@@ -222,6 +226,7 @@ as following:
 The following properties can then
 be queried from this isotope:
 
+- The mass of a specific isotope using `mass`.
 - The solar abundance of the isotope itself using `solar_abundance`,
   normed as discussed above
 - The relative abundance of the specific isotope
@@ -243,8 +248,8 @@ one could run the following two commands in python:
   0.058449999999999995
 
 
-Element and isotope ratios:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Element and isotope ratios
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This function is used to calculate element and isotope ratios.
 Sure, the same can be accomplished by simply
@@ -356,8 +361,8 @@ Some examples for isotope ratios:
 
 
 
-δ-values:
-~~~~~~~~~
+δ-values
+~~~~~~~~
 
 .. note:: A detailed discussion
   of δ-values can be found in the
@@ -464,8 +469,8 @@ Some examples for calculating δ-values for elements:
     array([696.48894668,  30.26124356])
 
 
-Bracket-notation:
-~~~~~~~~~~~~~~~~~
+Bracket-notation
+~~~~~~~~~~~~~~~~
 
 The bracket notation,
 generally used in astronomy,

--- a/iniabu/elements.py
+++ b/iniabu/elements.py
@@ -6,6 +6,7 @@ This class manages the elements. It must be called from :class:`iniabu.IniAbu`.
 
 import numpy as np
 
+from . import data
 from .utilities import return_list_simplifier
 
 
@@ -102,6 +103,25 @@ class Elements(object):
         ret_arr = []
         for ele in self._eles:
             ret_arr.append(np.array(self._ele_dict[ele][3], dtype=np.float))
+        return return_list_simplifier(ret_arr)
+
+    @property
+    def mass(self):
+        """Get the mass of an element.
+
+        Returns the mass of an element depending on the specified composition. The mass
+        is calculated as the weighted sum of the individual isotope masses, weighted
+        by there respective abundances.
+
+        :return: Mass of an element.
+        :rtype: float,ndarray<float>
+        """
+        ret_arr = []
+        for ele in self._eles:
+            isos = [f"{ele}-{a}" for a in self._ele_dict[ele][1]]
+            isos_abu = np.array([abu for abu in self._ele_dict[ele][2]])
+            isos_mass = np.array([data.isotopes_mass[iso] for iso in isos])
+            ret_arr.append(np.sum(isos_abu * isos_mass))
         return return_list_simplifier(ret_arr)
 
     @property

--- a/iniabu/isotopes.py
+++ b/iniabu/isotopes.py
@@ -6,6 +6,7 @@ This class manages the isotopes. It must be called from :class:`iniabu.IniAbu`.
 
 import numpy as np
 
+from . import data
 from .utilities import return_list_simplifier
 
 
@@ -54,6 +55,18 @@ class Isotopes(object):
             self._iso_dict = parent.iso_dict
 
     # PROPERTIES #
+
+    @property
+    def mass(self):
+        """Get the mass of an isotope.
+
+        :return: Mass of an isotope.
+        :rtype: float,ndarray<float>
+        """
+        ret_arr = []
+        for iso in self._isos:
+            ret_arr.append(data.isotopes_mass[iso])
+        return return_list_simplifier(ret_arr)
 
     @property
     def relative_abundance(self):

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -101,6 +101,27 @@ def test_isotopes_solar_abundance_nan(ini_nist, ele1, ele2):
     ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
     ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
 )
+def test_mass(ini_default, ele1, ele2):
+    """Query the mass of an element."""
+    isos1 = [f"{ele1}-{a}" for a in ini_default.ele_dict[ele1][1]]
+    isos_masses1 = np.array([iniabu.data.isotopes_mass[iso] for iso in isos1])
+    isos_abus1 = np.array(ini_default.ele_dict[ele1][2])
+    mass_expected1 = np.sum(isos_masses1 * isos_abus1)
+    assert ini_default.element[ele1].mass == mass_expected1
+
+    isos2 = [f"{ele2}-{a}" for a in ini_default.ele_dict[ele2][1]]
+    isos_masses2 = np.array([iniabu.data.isotopes_mass[iso] for iso in isos2])
+    isos_abus2 = np.array(ini_default.ele_dict[ele2][2])
+    mass_expected2 = np.sum(isos_masses2 * isos_abus2)
+    masses_expected = np.array([mass_expected1, mass_expected2])
+    masses_gotten = ini_default.element[[ele1, ele2]].mass
+    np.testing.assert_equal(masses_gotten, masses_expected)
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
 def test_solar_abundance(ini_default, ele1, ele2):
     """Test solar abundance property."""
     assert (

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -30,6 +30,22 @@ def test_isotopes_isos_list(ini_default, iso1, iso2):
     iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
 )
+def test_mass(ini_default, iso1, iso2):
+    """Get the mass of an isotope."""
+    mass_expected = iniabu.data.isotopes_mass[iso1]
+    assert ini_default.isotope[iso1].mass == mass_expected
+
+    masses_expected = np.array(
+        [iniabu.data.isotopes_mass[iso1], iniabu.data.isotopes_mass[iso2]]
+    )
+    masses_gotten = ini_default.isotope[[iso1, iso2]].mass
+    np.testing.assert_equal(masses_gotten, masses_expected)
+
+
+@given(
+    iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+    iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+)
 def test_relative_abundance(ini_default, iso1, iso2):
     """Test isotope relative abundance returner."""
     assert (


### PR DESCRIPTION
- Element masses are calculated based on the isotope masses and the
  currently loaded isotopic abundance. A good example is to compare the
  mass of uranium when using `lodders09` and `nist`.
- Isotope masses are simply taken from the NIST database on isotope
  masses.
- Updated documentation to include the masses
- Docstring should also be updated for API reference update.

In addition, also removed some `:` from the end of titles in the docs.