### PR TITLE
Refactoring for shorter function names

### DIFF
--- a/docs/api/utilities.rst
+++ b/docs/api/utilities.rst
@@ -12,10 +12,28 @@ Utility classes and functions
     :undoc-members:
 
 
-:func:`make_log_abundance_dictionaries`
----------------------------------------
+:func:`linear_units`
+--------------------
 
-.. autofunction:: make_log_abundance_dictionaries
+.. autofunction:: linear_units
+
+
+:func:`make_iso_dict`
+---------------------
+
+.. autofunction:: make_iso_dict
+
+
+:func:`make_log_abu_dict`
+-------------------------
+
+.. autofunction:: make_log_abu_dict
+
+
+:func:`make_mf_dict`
+---------------------
+
+.. autofunction:: make_mf_dict
 
 
 :func:`return_as_ndarray`

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -3,6 +3,14 @@
 Developer Reference
 ===================
 
+First off,
+please make sure you have read and understood
+our code of conduct.
+We expect everybody to adhere to it.
+You can find this project's
+code of condact
+`here <https://github.com/galactic-forensics/iniabu/blob/master/CODE_OF_CONDUCT.md>`_.
+
 To get started with developing,
 fork the github repository and
 clone it into a local directory.
@@ -92,7 +100,7 @@ Test driven development
 Testing of the ``iniabu`` package is done using ``pytest``
 and automated using ``nox``.
 To run a full test using ``nox``,
-Python 3.6, 3.7, and 3.8,
+Python 3.6, 3.7, 3.8, and 3.9,
 must be available in the environment.
 A full nox test, which includes
 linting, safety, and tests
@@ -221,17 +229,6 @@ from the terminal by typing:
 
     $ nox -rs lint
 
-For developing purposes,
-the ``nox`` session can also be limited
-to just run with one specific Python version,
-e.g., with Python 3.8.
-To do so,
-type on the terminal:
-
-.. code-block:: console
-
-    $ nox -rs lint -p 3.8
-
 To fix linting issues,
 read the output of the linter carefully.
 If absolutely required,
@@ -250,9 +247,6 @@ Testing
 ~~~~~~~
 
 Project testing is done with ``pytest``.
-An overview of all implemented tests
-can be found in the :doc:`/tests` section.
-
 The following ``pytest`` plugins
 are defined in the ``dev-requirements.txt`` file:
 
@@ -276,9 +270,9 @@ you can type the following into the terminal:
 
     $ nox -rs tests
 
-Again, adding the option ``-p 3.8``
+Again, adding the option ``-p 3.9``
 would limit the test to
-Python 3.8 only.
+Python 3.9 only.
 
 
 Docstring example testing
@@ -487,7 +481,7 @@ Then adjust the subroutines and associated asserts.
 At least make sure that tests exist for:
 
 - Data integrity
-- Solar abundance of Si is 1e6
+- Solar abundance of Si is 10\ :sup:`6`
 - Relative abundances of all isotopes sum to unity
 
 Finally, add a new test in ``test_main.py``

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -256,7 +256,7 @@ can be loaded into a variable as following:
 
 .. code-block:: python
 
-    >>> ele = ini.element["Si"]
+    >>> ele = ini.ele["Si"]
 
 The following properties can now be queried
 from the element:
@@ -265,15 +265,15 @@ from the element:
   calculated using the isotope masses
   and the currently loaded abundances,
   using ``mass``.
-- The solar abundance of the element itself using ``solar_abundance``,
+- The solar abundance of the element itself using ``abu_solar``,
   normed as discussed above
-- The mass number of its (stable) isotopes using ``isotopes_a``
+- The mass number of its (stable) isotopes using ``iso_a``
 - The relative abundances of its (stable) isotopes using
-  ``isotopes_relative_abundance``.
+  ``iso_abu_rel``.
   If you are using "mass_fractions" as units,
   the relative abundances will also be given
   as mass fractions!
-- The solar abundances of its (stable) isotopes using ``isotopes_solar_abundance``
+- The solar abundances of its (stable) isotopes using ``iso_abu_solar``
 
 For example,
 to query the solar abundance of iron
@@ -281,8 +281,8 @@ one could run the following statement:
 
 .. code-block:: python
 
-   >>> ele = ini.element["Fe"]
-   >>> ele.solar_abundance
+   >>> ele = ini.ele["Fe"]
+   >>> ele.abu_solar
    847990.0
 
 
@@ -301,16 +301,16 @@ as following:
 
 .. code-block:: python
 
-    >>> iso = ini.isotope["Fe-54"]
+    >>> iso = ini.iso["Fe-54"]
 
 The following properties can then
 be queried from this isotope:
 
 - The mass of a specific isotope using ``mass``.
-- The solar abundance of the isotope itself using ``solar_abundance``,
+- The solar abundance of the isotope itself using ``abu_solar``,
   normed as discussed above
 - The relative abundance of the specific isotope
-  with respect to the element using ``relative_abundance``.
+  with respect to the element using ``abu_rel``.
   *Note*: All isotopes of an element
   would sum up to a relative abundance of 1.
   If you are using "mass_fractions" as units,
@@ -324,10 +324,10 @@ one could run the following two commands in python:
 
 .. code-block:: python
 
-  >>> iso = ini.isotope["Fe-54"]
-  >>> iso.solar_abundance
+  >>> iso = ini.iso["Fe-54"]
+  >>> iso.abu_solar
   49600.0
-  >>> iso.relative_abundance
+  >>> iso.abu_rel
   0.058449999999999995
 
 
@@ -364,7 +364,7 @@ Some additional benefits when calculating isotope ratios:
   using these ratios.
 
 The functions to calculate these ratios are called
-``ratio_element`` and ``ratio_isotope``.
+``ele_ratio`` and ``iso_ratio``.
 Below are some examples
 that describe some standard usage of these routines:
 
@@ -387,9 +387,9 @@ Some examples for elemental ratios:
 
   .. code-block:: python
 
-    >>> ini.ratio_element("He", "Pb")  # number fraction
+    >>> ini.ele_ratio("He", "Pb")  # number fraction
     759537205.0816697
-    >>> ini.ratio_element("He", "Pb", mass_fraction=True)
+    >>> ini.ele_ratio("He", "Pb", mass_fraction=True)
     39321659726.58637
 
 - Calculate multiple element ratios
@@ -398,7 +398,7 @@ Some examples for elemental ratios:
 
   .. code-block:: python
 
-    >>> ini.ratio_element(["Fe", "Ni"], "Si")
+    >>> ini.ele_ratio(["Fe", "Ni"], "Si")
     array([0.84824447, 0.04910773])
 
 - Calculate multiple element ratios
@@ -407,7 +407,7 @@ Some examples for elemental ratios:
 
   .. code-block:: python
 
-    >>> ini.ratio_element(["Si", "Ni"], ["Fe", "Zr"])
+    >>> ini.ele_ratio(["Si", "Ni"], ["Fe", "Zr"])
     array([1.17890541e+00, 4.55450413e+03])
 
 
@@ -421,9 +421,9 @@ Some examples for isotope ratios:
 
   .. code-block:: python
 
-    >>> ini.ratio_isotope("Li-6", "Li-7")  # number fractions by default
+    >>> ini.iso_ratio("Li-6", "Li-7")  # number fractions by default
     0.08212225817272835
-    >>> ini.ratio_isotope("Li-6", "Li-7", mass_fraction=True)
+    >>> ini.iso_ratio("Li-6", "Li-7", mass_fraction=True)
     0.09578691181324486
 
 - Calculate isotope fractions of :sup:`3`\He to :sup:`4`\He
@@ -431,7 +431,7 @@ Some examples for isotope ratios:
 
   .. code-block:: python
 
-    >>> ini.ratio_isotope(["He-3", "Ne-21"], ["He-4", "Ne-20"])
+    >>> ini.iso_ratio(["He-3", "Ne-21"], ["He-4", "Ne-20"])
     array([0.00016603, 0.00239717])
 
 - Calculate the isotope ratios of all Si isotopes
@@ -448,11 +448,11 @@ Some examples for isotope ratios:
 
   .. code-block:: python
 
-    >>> ini.ratio_isotope(["Si-28", "Si-29", "Si-30"], "Si-28")  # Method 1
+    >>> ini.iso_ratio(["Si-28", "Si-29", "Si-30"], "Si-28")  # Method 1
     array([1.        , 0.05077524, 0.03347067])
-    >>> ini.ratio_isotope("Si", "Si-28")  # Method 2
+    >>> ini.iso_ratio("Si", "Si-28")  # Method 2
     array([1.        , 0.05077524, 0.03347067])
-    >>> ini.ratio_isotope("Si", "Si")  # Method 3
+    >>> ini.iso_ratio("Si", "Si")  # Method 3
     array([1.        , 0.05077524, 0.03347067])
 
 
@@ -497,16 +497,16 @@ to overwrite the behavior of the loaded units.
 While δ-values are commonly calculated for isotopes of one individual element,
 the routine allows to calculate δ-values between isotopes of different elements.
 To calculate a δ-values of two elements,
-the ``delta_element`` function should be used.
+the ``ele_delta`` function should be used.
 The equation given above represents a specific,
 but most commonly used case.
 
-Finally: The ``delta_isotope``
-and ``delta_element`` functions
+Finally: The ``iso_delta``
+and ``ele_delta`` functions
 have the same features
 for specifying the nominator and denominator
-as the ``ratio_isotope``
-and ``ratio_element`` functions mentioned above.
+as the ``iso_ratio``
+and ``ele_ratio`` functions mentioned above.
 
 .. caution:: The values must be given in the same shape
   as the number of ratios provided.
@@ -522,9 +522,9 @@ Some examples for calculating δ-values for isotopes:
 
   .. code-block:: python
 
-    >>> ini.delta_isotope("Si-30", "Si-28", 0.04)  # parts per thousand (default)
+    >>> ini.iso_delta("Si-30", "Si-28", 0.04)  # parts per thousand (default)
     195.0761256883704
-    >>> ini.delta_isotope("Si-30", "Si-28", 0.04, delta_factor=100)  # percent
+    >>> ini.iso_delta("Si-30", "Si-28", 0.04, delta_factor=100)  # percent
     19.50761256883704
 
 - Calculate multiple δ-values as mass fractions.
@@ -537,11 +537,11 @@ Some examples for calculating δ-values for isotopes:
   .. code-block:: python
 
     >>> msr = [1., 0.01, 0.04]  # measurement
-    >>> ini.delta_isotope(["Si-28", "Si-29", "Si-30"], "Si-28", msr)
+    >>> ini.iso_delta(["Si-28", "Si-29", "Si-30"], "Si-28", msr)
     array([   0.        , -803.05359812,  195.07612569])
-    >>> ini.delta_isotope("Si", "Si-28", msr)
+    >>> ini.iso_delta("Si", "Si-28", msr)
     array([   0.        , -803.05359812,  195.07612569])
-    >>> ini.delta_isotope("Si", "Si", msr)
+    >>> ini.iso_delta("Si", "Si", msr)
     array([   0.        , -803.05359812,  195.07612569])
 
 - Calculate the δ-value for :sup:`84`\Sr
@@ -552,7 +552,7 @@ Some examples for calculating δ-values for isotopes:
 
   .. code-block:: python
 
-    >>> ini.delta_isotope("Sr-84", "Sr", 0.01, mass_fraction=True)
+    >>> ini.iso_delta("Sr-84", "Sr", 0.01, mass_fraction=True)
     414.3962670607242
 
 
@@ -563,7 +563,7 @@ Some examples for calculating δ-values for elements:
 
   .. code-block:: python
 
-    >>>  ini.delta_element(["Si", "Ne"], "Fe", [2, 4])
+    >>>  ini.ele_delta(["Si", "Ne"], "Fe", [2, 4])
     array([696.48894668,  30.26124356])
 
 
@@ -595,14 +595,14 @@ While bracket notation is commonly used with elements,
 there is no mathematical reason to prohibit using it for isotopes.
 Therefore,
 two routines are provided,
-namely ``bracket_element`` and ``bracket_isotope``.
+namely ``ele_bracket`` and ``iso_bracket``.
 
-Finally: The ``bracket_element``
-and ``bracket_isotope`` functions
+Finally: The ``ele_bracket``
+and ``iso_bracket`` functions
 have the same features
 for specifying the nominator and denominator
-as the ``ratio_isotope``
-and ``ratio_element`` functions mentioned above.
+as the ``iso_ratio``
+and ``ele_ratio`` functions mentioned above.
 
 
 Some examples for calculating bracket notation values for elements:
@@ -615,9 +615,9 @@ Some examples for calculating bracket notation values for elements:
 
   .. code-block:: python
 
-    >>> ini.bracket_element("Fe", "H", 0.005)  # number fraction
+    >>> ini.ele_bracket("Fe", "H", 0.005)  # number fraction
     2.183887471873783
-    >>> ini.bracket_element("Fe", "H", 0.005, mass_fraction=True)  # mass fraction
+    >>> ini.ele_bracket("Fe", "H", 0.005, mass_fraction=True)  # mass fraction
     3.9274378849968263
 
 - Calculate bracket notation value
@@ -626,7 +626,7 @@ Some examples for calculating bracket notation values for elements:
 
   .. code-block:: python
 
-    >>> ini.bracket_element(["O", "Fe"], "H", [0.02, 0.005])
+    >>> ini.ele_bracket(["O", "Fe"], "H", [0.02, 0.005])
     array([1.51740521, 2.18388747])
 
 
@@ -641,9 +641,9 @@ Some examples for calculating bracket notation values for isotopes:
   .. code-block:: python
 
     >>> msr = [1., 0.01, 0.04]
-    >>>  ini.bracket_isotope(["Si-28", "Si-29", "Si-30"], "Si-28", msr)
+    >>>  ini.iso_bracket(["Si-28", "Si-29", "Si-30"], "Si-28", msr)
     array([ 0.        , -0.70565195,  0.07739557])
-    >>> ini.bracket_isotope("Si", "Si-28", msr)
+    >>> ini.iso_bracket("Si", "Si-28", msr)
     array([ 0.        , -0.70565195,  0.07739557])
-    >>> ini.bracket_isotope("Si", "Si", msr)
+    >>> ini.iso_bracket("Si", "Si", msr)
     array([ 0.        , -0.70565195,  0.07739557])

--- a/iniabu/elements.py
+++ b/iniabu/elements.py
@@ -19,8 +19,8 @@ class Elements(object):
         >>> from iniabu import ini
         >>> ini.unit
         'num_lin'
-        >>> element = ini.element["Si"]
-        >>> element.solar_abundance
+        >>> element = ini.ele["Si"]
+        >>> element.abu_solar
         999700.0
 
     .. warning:: This class should NOT be manually created by the user. It is
@@ -66,7 +66,25 @@ class Elements(object):
     # PROPERTIES #
 
     @property
-    def isotopes_a(self):
+    def abu_solar(self):
+        """Get solar abundance of element(s).
+
+        Returns the solar abundance of the selected element(s). Returns the result
+        either as a ``float`` or as a numpy ``ndarray``. Note: Not all databases contain
+        this information. If the information is not available, these values will be
+        filled with ``np.nan``.
+
+        :return: Solar abundance of element(s)
+        :rtype: float,ndarray
+        """
+        ret_arr = []
+        for ele in self._eles:
+            ret_arr.append(self._ele_dict[ele][0])
+        ret_arr = np.array(ret_arr)
+        return return_list_simplifier(ret_arr)
+
+    @property
+    def iso_a(self):
         """Get the atomic number(s) of all isotopes.
 
         Returns the atomic number(s) of all isotopes of this element as a numpy integer
@@ -82,7 +100,7 @@ class Elements(object):
         return return_list_simplifier(ret_arr)
 
     @property
-    def isotopes_relative_abundance(self):
+    def iso_abu_rel(self):
         """Get relative abundance of all isotopes.
 
         Returns a list with the relative abundances of all isotopes of the given
@@ -99,7 +117,7 @@ class Elements(object):
         return return_list_simplifier(ret_arr)
 
     @property
-    def isotopes_solar_abundance(self):
+    def iso_abu_solar(self):
         """Get solar abundances of all isotopes.
 
         Returns a list with the solar abundances of all isotopes of the given element.
@@ -132,22 +150,4 @@ class Elements(object):
             isos_abu = np.array([abu for abu in self._ele_dict[ele][2]])
             isos_mass = np.array([data.isotopes_mass[iso] for iso in isos])
             ret_arr.append(np.sum(isos_abu * isos_mass))
-        return return_list_simplifier(ret_arr)
-
-    @property
-    def solar_abundance(self):
-        """Get solar abundance of element(s).
-
-        Returns the solar abundance of the selected element(s). Returns the result
-        either as a ``float`` or as a numpy ``ndarray``. Note: Not all databases contain
-        this information. If the information is not available, these values will be
-        filled with ``np.nan``.
-
-        :return: Solar abundance of element(s)
-        :rtype: float,ndarray
-        """
-        ret_arr = []
-        for ele in self._eles:
-            ret_arr.append(self._ele_dict[ele][0])
-        ret_arr = np.array(ret_arr)
         return return_list_simplifier(ret_arr)

--- a/iniabu/isotopes.py
+++ b/iniabu/isotopes.py
@@ -17,8 +17,8 @@ class Isotopes(object):
 
     Example:
         >>> from iniabu import ini
-        >>> isotope = ini.isotope["Si-28"]
-        >>> isotope.relative_abundance
+        >>> isotope = ini.iso["Si-28"]
+        >>> isotope.abu_rel
         0.9223
 
     .. warning:: This class should NOT be manually created by the user. It is
@@ -64,19 +64,7 @@ class Isotopes(object):
     # PROPERTIES #
 
     @property
-    def mass(self):
-        """Get the mass of an isotope.
-
-        :return: Mass of an isotope.
-        :rtype: float,ndarray<float>
-        """
-        ret_arr = []
-        for iso in self._isos:
-            ret_arr.append(data.isotopes_mass[iso])
-        return return_list_simplifier(ret_arr)
-
-    @property
-    def relative_abundance(self):
+    def abu_rel(self):
         """Get relative abundance of isotope(s).
 
         Returns the relative abundance of the selected isotope(s). Returns the result
@@ -94,7 +82,7 @@ class Isotopes(object):
         return return_list_simplifier(ret_arr)
 
     @property
-    def solar_abundance(self):
+    def abu_solar(self):
         """Get solar abundance of isotope(s).
 
         Returns the solar abundance of the selected isotope(s). Returns the result
@@ -109,4 +97,16 @@ class Isotopes(object):
         for iso in self._isos:
             ret_arr.append(self._iso_dict[iso][1])
         ret_arr = np.array(ret_arr)
+        return return_list_simplifier(ret_arr)
+
+    @property
+    def mass(self):
+        """Get the mass of an isotope.
+
+        :return: Mass of an isotope.
+        :rtype: float,ndarray<float>
+        """
+        ret_arr = []
+        for iso in self._isos:
+            ret_arr.append(data.isotopes_mass[iso])
         return return_list_simplifier(ret_arr)

--- a/iniabu/utilities.py
+++ b/iniabu/utilities.py
@@ -100,7 +100,7 @@ def linear_units(ini, mass_fraction):
         ini.unit = current_units
 
 
-def make_isotope_dictionary(element_dict):
+def make_iso_dict(element_dict):
     """Make an isotope dictionary from an element dictionary.
 
     :param element_dict: Element dictionary.
@@ -120,7 +120,7 @@ def make_isotope_dictionary(element_dict):
     return dict(zip(iso_keys, iso_entries))
 
 
-def make_log_abundance_dictionaries(element_dict):
+def make_log_abu_dict(element_dict):
     """Make element and isotope dictionaries for logarithmic abundances.
 
     This routine takes an element dictionary with linear abundances, normed to Si
@@ -163,12 +163,12 @@ def make_log_abundance_dictionaries(element_dict):
     element_dict_log = dict(zip(ele_keys, ele_entries))
 
     # isotope dictionary
-    isotope_dict_log = make_isotope_dictionary(element_dict_log)
+    isotope_dict_log = make_iso_dict(element_dict_log)
 
     return element_dict_log, isotope_dict_log
 
 
-def make_mass_fraction_dictionary(element_dict):
+def make_mf_dict(element_dict):
     """Make element and isotope dictionaries for mass fractions.
 
     This routine takes an element dictionary with linear abundances, normed to Si
@@ -211,7 +211,7 @@ def make_mass_fraction_dictionary(element_dict):
             element_dict_mf[key][2][it] = sol_abu_val / abu_sum
 
     # make isotope mass fraction dictionary
-    isotope_dict_mf = make_isotope_dictionary(element_dict_mf)
+    isotope_dict_mf = make_iso_dict(element_dict_mf)
 
     return element_dict_mf, isotope_dict_mf
 

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -33,151 +33,18 @@ def test_elements_wrong_unit():
 )
 def test_elements_eles_list(ini_default, ele1, ele2):
     """Test that the element list is correctly initialized."""
-    assert ini_default.element[ele1]._eles == [ele1]
-    assert ini_default.element[[ele1, ele2]]._eles == [ele1, ele2]
+    assert ini_default.ele[ele1]._eles == [ele1]
+    assert ini_default.ele[[ele1, ele2]]._eles == [ele1, ele2]
 
 
 @given(
     ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
     ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
 )
-def test_isotopes_a(ini_default, ele1, ele2):
-    """Test isotope atomic number returner."""
-    assert (
-        ini_default.element[ele1].isotopes_a
-        == np.array(iniabu.data.lodders09_elements[ele1][1])
-    ).all()
-
-    left = ini_default.element[[ele1, ele2]].isotopes_a
-    right = [
-        np.array(iniabu.data.lodders09_elements[ele1][1]),
-        np.array(iniabu.data.lodders09_elements[ele2][1]),
-    ]
-    np.testing.assert_equal(left, right)
-
-
-@given(
-    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-)
-def test_isotopes_relative_abundance(ini_default, ele1, ele2):
-    """Test isotope relative abundance returner."""
-    assert (
-        ini_default.element[ele1].isotopes_relative_abundance
-        == np.array(iniabu.data.lodders09_elements[ele1][2])
-    ).all()
-
-    left = ini_default.element[[ele1, ele2]].isotopes_relative_abundance
-    right = [
-        np.array(iniabu.data.lodders09_elements[ele1][2]),
-        np.array(iniabu.data.lodders09_elements[ele2][2]),
-    ]
-    np.testing.assert_equal(left, right)
-
-
-@given(
-    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-)
-def test_isotopes_solar_abundance(ini_default, ele1, ele2):
-    """Test isotope solar abundance returner."""
-    assert (
-        ini_default.element[ele1].isotopes_solar_abundance
-        == np.array(iniabu.data.lodders09_elements[ele1][3])
-    ).all()
-
-    left = ini_default.element[[ele1, ele2]].isotopes_solar_abundance
-    right = [
-        np.array(iniabu.data.lodders09_elements[ele1][3]),
-        np.array(iniabu.data.lodders09_elements[ele2][3]),
-    ]
-    np.testing.assert_equal(left, right)
-
-
-@given(
-    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-)
-def test_isotopes_solar_abundance_log(ele1, ele2):
-    """Test isotope solar abundance returner."""
-    ini = iniabu.IniAbu(unit="num_log")
-    assert (
-        ini.element[ele1].isotopes_solar_abundance
-        == np.array(ini.ele_dict_log[ele1][3])
-    ).all()
-
-    left = ini.element[[ele1, ele2]].isotopes_solar_abundance
-    right = [
-        np.array(ini.ele_dict_log[ele1][3]),
-        np.array(ini.ele_dict_log[ele2][3]),
-    ]
-    np.testing.assert_equal(left, right)
-
-
-@given(
-    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-)
-def test_isotopes_solar_abundance_mf(ele1, ele2):
-    """Test isotope solar abundance returner."""
-    ini = iniabu.IniAbu(unit="mass_fraction")
-    assert (
-        ini.element[ele1].isotopes_solar_abundance == np.array(ini.ele_dict_mf[ele1][3])
-    ).all()
-
-    left = ini.element[[ele1, ele2]].isotopes_solar_abundance
-    right = [
-        np.array(ini.ele_dict_mf[ele1][3]),
-        np.array(ini.ele_dict_mf[ele2][3]),
-    ]
-    np.testing.assert_equal(left, right)
-
-
-@given(
-    ele1=st.sampled_from(list(iniabu.data.nist15_elements.keys())),
-    ele2=st.sampled_from(list(iniabu.data.nist15_elements.keys())),
-)
-def test_isotopes_solar_abundance_nan(ini_nist, ele1, ele2):
-    """Test isotope solar abundance returner when not available."""
-    # make sure np.nan is returned for other databases
-    assert np.isnan(ini_nist.element[ele1].isotopes_solar_abundance).all()
-
-    val = ini_nist.element[[ele1, ele2]].isotopes_solar_abundance
-    assert all([np.isnan(it).all() for it in val])
-
-
-@given(
-    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-)
-def test_mass(ini_default, ele1, ele2):
-    """Query the mass of an element."""
-    isos1 = [f"{ele1}-{a}" for a in ini_default.ele_dict[ele1][1]]
-    isos_masses1 = np.array([iniabu.data.isotopes_mass[iso] for iso in isos1])
-    isos_abus1 = np.array(ini_default.ele_dict[ele1][2])
-    mass_expected1 = np.sum(isos_masses1 * isos_abus1)
-    assert ini_default.element[ele1].mass == mass_expected1
-
-    isos2 = [f"{ele2}-{a}" for a in ini_default.ele_dict[ele2][1]]
-    isos_masses2 = np.array([iniabu.data.isotopes_mass[iso] for iso in isos2])
-    isos_abus2 = np.array(ini_default.ele_dict[ele2][2])
-    mass_expected2 = np.sum(isos_masses2 * isos_abus2)
-    masses_expected = np.array([mass_expected1, mass_expected2])
-    masses_gotten = ini_default.element[[ele1, ele2]].mass
-    np.testing.assert_equal(masses_gotten, masses_expected)
-
-
-@given(
-    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
-)
-def test_solar_abundance(ini_default, ele1, ele2):
+def test_abu_solar(ini_default, ele1, ele2):
     """Test solar abundance property."""
-    assert (
-        ini_default.element[ele1].solar_abundance
-        == iniabu.data.lodders09_elements[ele1][0]
-    )
-    left = ini_default.element[[ele1, ele2]].solar_abundance
+    assert ini_default.ele[ele1].abu_solar == iniabu.data.lodders09_elements[ele1][0]
+    left = ini_default.ele[[ele1, ele2]].abu_solar
     right = np.array(
         [
             iniabu.data.lodders09_elements[ele1][0],
@@ -191,7 +58,131 @@ def test_solar_abundance(ini_default, ele1, ele2):
     ele1=st.sampled_from(list(iniabu.data.nist15_elements.keys())),
     ele2=st.sampled_from(list(iniabu.data.nist15_elements.keys())),
 )
-def test_solar_abundance_nan(ini_nist, ele1, ele2):
+def test_abu_solar_nan(ini_nist, ele1, ele2):
     """Test solar abundance property when not available."""
-    assert np.isnan(ini_nist.element[ele1].solar_abundance)
-    assert np.isnan(ini_nist.element[[ele1, ele2]].solar_abundance).all()
+    assert np.isnan(ini_nist.ele[ele1].abu_solar)
+    assert np.isnan(ini_nist.ele[[ele1, ele2]].abu_solar).all()
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
+def test_iso_a(ini_default, ele1, ele2):
+    """Test isotope atomic number returner."""
+    assert (
+        ini_default.ele[ele1].iso_a == np.array(iniabu.data.lodders09_elements[ele1][1])
+    ).all()
+
+    left = ini_default.ele[[ele1, ele2]].iso_a
+    right = [
+        np.array(iniabu.data.lodders09_elements[ele1][1]),
+        np.array(iniabu.data.lodders09_elements[ele2][1]),
+    ]
+    np.testing.assert_equal(left, right)
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
+def test_iso_abu_rel(ini_default, ele1, ele2):
+    """Test isotope relative abundance returner."""
+    assert (
+        ini_default.ele[ele1].iso_abu_rel
+        == np.array(iniabu.data.lodders09_elements[ele1][2])
+    ).all()
+
+    left = ini_default.ele[[ele1, ele2]].iso_abu_rel
+    right = [
+        np.array(iniabu.data.lodders09_elements[ele1][2]),
+        np.array(iniabu.data.lodders09_elements[ele2][2]),
+    ]
+    np.testing.assert_equal(left, right)
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
+def test_iso_abu_solar(ini_default, ele1, ele2):
+    """Test isotope solar abundance returner."""
+    assert (
+        ini_default.ele[ele1].iso_abu_solar
+        == np.array(iniabu.data.lodders09_elements[ele1][3])
+    ).all()
+
+    left = ini_default.ele[[ele1, ele2]].iso_abu_solar
+    right = [
+        np.array(iniabu.data.lodders09_elements[ele1][3]),
+        np.array(iniabu.data.lodders09_elements[ele2][3]),
+    ]
+    np.testing.assert_equal(left, right)
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
+def test_iso_abu_solarlog(ele1, ele2):
+    """Test isotope solar abundance returner."""
+    ini = iniabu.IniAbu(unit="num_log")
+    assert (ini.ele[ele1].iso_abu_solar == np.array(ini.ele_dict_log[ele1][3])).all()
+
+    left = ini.ele[[ele1, ele2]].iso_abu_solar
+    right = [
+        np.array(ini.ele_dict_log[ele1][3]),
+        np.array(ini.ele_dict_log[ele2][3]),
+    ]
+    np.testing.assert_equal(left, right)
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
+def test_iso_abu_solarmf(ele1, ele2):
+    """Test isotope solar abundance returner."""
+    ini = iniabu.IniAbu(unit="mass_fraction")
+    assert (ini.ele[ele1].iso_abu_solar == np.array(ini.ele_dict_mf[ele1][3])).all()
+
+    left = ini.ele[[ele1, ele2]].iso_abu_solar
+    right = [
+        np.array(ini.ele_dict_mf[ele1][3]),
+        np.array(ini.ele_dict_mf[ele2][3]),
+    ]
+    np.testing.assert_equal(left, right)
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.nist15_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.nist15_elements.keys())),
+)
+def test_iso_abu_solarnan(ini_nist, ele1, ele2):
+    """Test isotope solar abundance returner when not available."""
+    # make sure np.nan is returned for other databases
+    assert np.isnan(ini_nist.ele[ele1].iso_abu_solar).all()
+
+    val = ini_nist.ele[[ele1, ele2]].iso_abu_solar
+    assert all([np.isnan(it).all() for it in val])
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
+def test_mass(ini_default, ele1, ele2):
+    """Query the mass of an element."""
+    isos1 = [f"{ele1}-{a}" for a in ini_default.ele_dict[ele1][1]]
+    isos_masses1 = np.array([iniabu.data.isotopes_mass[iso] for iso in isos1])
+    isos_abus1 = np.array(ini_default.ele_dict[ele1][2])
+    mass_expected1 = np.sum(isos_masses1 * isos_abus1)
+    assert ini_default.ele[ele1].mass == mass_expected1
+
+    isos2 = [f"{ele2}-{a}" for a in ini_default.ele_dict[ele2][1]]
+    isos_masses2 = np.array([iniabu.data.isotopes_mass[iso] for iso in isos2])
+    isos_abus2 = np.array(ini_default.ele_dict[ele2][2])
+    mass_expected2 = np.sum(isos_masses2 * isos_abus2)
+    masses_expected = np.array([mass_expected1, mass_expected2])
+    masses_gotten = ini_default.ele[[ele1, ele2]].mass
+    np.testing.assert_equal(masses_gotten, masses_expected)

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -32,37 +32,18 @@ def test_isotopes_wrong_unit():
 )
 def test_isotopes_isos_list(ini_default, iso1, iso2):
     """Test that the isotope list is correctly initialized."""
-    assert ini_default.isotope[iso1]._isos == [iso1]
-    assert ini_default.isotope[[iso1, iso2]]._isos == [iso1, iso2]
+    assert ini_default.iso[iso1]._isos == [iso1]
+    assert ini_default.iso[[iso1, iso2]]._isos == [iso1, iso2]
 
 
 @given(
     iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
 )
-def test_mass(ini_default, iso1, iso2):
-    """Get the mass of an isotope."""
-    mass_expected = iniabu.data.isotopes_mass[iso1]
-    assert ini_default.isotope[iso1].mass == mass_expected
-
-    masses_expected = np.array(
-        [iniabu.data.isotopes_mass[iso1], iniabu.data.isotopes_mass[iso2]]
-    )
-    masses_gotten = ini_default.isotope[[iso1, iso2]].mass
-    np.testing.assert_equal(masses_gotten, masses_expected)
-
-
-@given(
-    iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
-    iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
-)
-def test_relative_abundance(ini_default, iso1, iso2):
+def test_abu_rel(ini_default, iso1, iso2):
     """Test isotope relative abundance returner."""
-    assert (
-        ini_default.isotope[iso1].relative_abundance
-        == iniabu.data.lodders09_isotopes[iso1][0]
-    )
-    left = ini_default.isotope[[iso1, iso2]].relative_abundance
+    assert ini_default.iso[iso1].abu_rel == iniabu.data.lodders09_isotopes[iso1][0]
+    left = ini_default.iso[[iso1, iso2]].abu_rel
     right = np.array(
         [
             iniabu.data.lodders09_isotopes[iso1][0],
@@ -76,13 +57,10 @@ def test_relative_abundance(ini_default, iso1, iso2):
     iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
 )
-def test_solar_abundance(ini_default, iso1, iso2):
+def test_abu_solar(ini_default, iso1, iso2):
     """Test isotope solar abundance returner."""
-    assert (
-        ini_default.isotope[iso1].solar_abundance
-        == iniabu.data.lodders09_isotopes[iso1][1]
-    )
-    left = ini_default.isotope[[iso1, iso2]].solar_abundance
+    assert ini_default.iso[iso1].abu_solar == iniabu.data.lodders09_isotopes[iso1][1]
+    left = ini_default.iso[[iso1, iso2]].abu_solar
     right = np.array(
         [
             iniabu.data.lodders09_isotopes[iso1][1],
@@ -96,13 +74,11 @@ def test_solar_abundance(ini_default, iso1, iso2):
     iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
 )
-def test_solar_abundance_log(ini_default, iso1, iso2):
+def test_abu_solar_log(ini_default, iso1, iso2):
     """Test isotope solar abundance returner - log units."""
     ini_default.unit = "num_log"
-    assert (
-        ini_default.isotope[iso1].solar_abundance == ini_default.iso_dict_log[iso1][1]
-    )
-    left = ini_default.isotope[[iso1, iso2]].solar_abundance
+    assert ini_default.iso[iso1].abu_solar == ini_default.iso_dict_log[iso1][1]
+    left = ini_default.iso[[iso1, iso2]].abu_solar
     right = np.array(
         [ini_default.iso_dict_log[iso1][1], ini_default.iso_dict_log[iso2][1]]
     )
@@ -113,11 +89,11 @@ def test_solar_abundance_log(ini_default, iso1, iso2):
     iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
 )
-def test_solar_abundance_mf(ini_default, iso1, iso2):
+def test_abu_solar_mf(ini_default, iso1, iso2):
     """Test isotope solar abundance returner - mass fraction."""
     ini_default.unit = "mass_fraction"
-    assert ini_default.isotope[iso1].solar_abundance == ini_default.iso_dict_mf[iso1][1]
-    left = ini_default.isotope[[iso1, iso2]].solar_abundance
+    assert ini_default.iso[iso1].abu_solar == ini_default.iso_dict_mf[iso1][1]
+    left = ini_default.iso[[iso1, iso2]].abu_solar
     right = np.array(
         [ini_default.iso_dict_mf[iso1][1], ini_default.iso_dict_mf[iso2][1]]
     )
@@ -128,8 +104,24 @@ def test_solar_abundance_mf(ini_default, iso1, iso2):
     iso1=st.sampled_from(list(iniabu.data.nist15_isotopes.keys())),
     iso2=st.sampled_from(list(iniabu.data.nist15_isotopes.keys())),
 )
-def test_solar_abundance_nan(ini_nist, iso1, iso2):
+def test_abu_solar_nan(ini_nist, iso1, iso2):
     """Test isotope solar abundance returner if not available."""
     # check with database that does not contain this
-    assert np.isnan(ini_nist.isotope[iso1].solar_abundance)
-    assert np.isnan(ini_nist.isotope[[iso1, iso2]].solar_abundance).all()
+    assert np.isnan(ini_nist.iso[iso1].abu_solar)
+    assert np.isnan(ini_nist.iso[[iso1, iso2]].abu_solar).all()
+
+
+@given(
+    iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+    iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+)
+def test_mass(ini_default, iso1, iso2):
+    """Get the mass of an isotope."""
+    mass_expected = iniabu.data.isotopes_mass[iso1]
+    assert ini_default.iso[iso1].mass == mass_expected
+
+    masses_expected = np.array(
+        [iniabu.data.isotopes_mass[iso1], iniabu.data.isotopes_mass[iso2]]
+    )
+    masses_gotten = ini_default.iso[[iso1, iso2]].mass
+    np.testing.assert_equal(masses_gotten, masses_expected)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -86,7 +86,7 @@ def test_unit_log(ele):
     ini = iniabu.IniAbu()
     ini.unit = "num_log"
     assert ini.unit == "num_log"
-    assert ini.element[ele].solar_abundance == ini.ele_dict_log[ele][0]
+    assert ini.ele[ele].abu_solar == ini.ele_dict_log[ele][0]
 
 
 @given(ele=st.sampled_from(list(data.lodders09_elements.keys())))
@@ -95,7 +95,7 @@ def test_unit_mf(ele):
     ini = iniabu.IniAbu()
     ini.unit = "mass_fraction"
     assert ini.unit == "mass_fraction"
-    assert ini.element[ele].solar_abundance == ini.ele_dict_mf[ele][0]
+    assert ini.ele[ele].abu_solar == ini.ele_dict_mf[ele][0]
 
 
 @given(ele=st.sampled_from(list(data.lodders09_elements.keys())))
@@ -103,10 +103,10 @@ def test_unit_log_lin(ele):
     """Ensure linear abundance unit is set correctly after logarithmic (switch back)."""
     ini = iniabu.IniAbu()
     ini.unit = "num_log"
-    assert ini.element[ele].solar_abundance == ini.ele_dict_log[ele][0]
+    assert ini.ele[ele].abu_solar == ini.ele_dict_log[ele][0]
     ini.unit = "num_lin"
     assert ini.unit == "num_lin"
-    assert ini.element[ele].solar_abundance == ini.ele_dict[ele][0]
+    assert ini.ele[ele].abu_solar == ini.ele_dict[ele][0]
 
 
 def test_unit_invalid(ini_default):
@@ -123,19 +123,19 @@ def test_unit_invalid(ini_default):
     ele2=st.sampled_from(list(data.lodders09_elements.keys())),
     value=st.floats(min_value=0, exclude_min=True),
 )
-def test_bracket_element(ini_default, ele1, ele2, value):
+def test_ele_bracket(ini_default, ele1, ele2, value):
     """Calculate bracket notation for an element ratio."""
     val_exp = np.log10(value) - np.log10(
         ini_default.ele_dict[ele1][0] / ini_default.ele_dict[ele2][0]
     )
-    val_get = ini_default.bracket_element(ele1, ele2, value)
+    val_get = ini_default.ele_bracket(ele1, ele2, value)
     assert val_get == val_exp
 
 
-def test_bracket_element_shape_mismatch(ini_default):
+def test_ele_bracket_shape_mismatch(ini_default):
     """Raise Value error on shape mismatch between nd arrays."""
     with pytest.raises(ValueError) as err_info:
-        ini_default.bracket_element(["Ne", "Mg"], ["Si", "Si"], 33)
+        ini_default.ele_bracket(["Ne", "Mg"], ["Si", "Si"], 33)
     err_msg = err_info.value.args[0]
     assert (
         err_msg == "Length of requested element ratios does not match length of "
@@ -148,19 +148,19 @@ def test_bracket_element_shape_mismatch(ini_default):
     iso2=st.sampled_from(list(data.lodders09_isotopes.keys())),
     value=st.floats(min_value=0, exclude_min=True),
 )
-def test_bracket_isotope(ini_default, iso1, iso2, value):
+def test_iso_bracket(ini_default, iso1, iso2, value):
     """Calculate bracket notation for an isotope ratio."""
     val_exp = np.log10(value) - np.log10(
         ini_default.iso_dict[iso1][1] / ini_default.iso_dict[iso2][1]
     )
-    val_get = ini_default.bracket_isotope(iso1, iso2, value)
+    val_get = ini_default.iso_bracket(iso1, iso2, value)
     assert val_get == val_exp
 
 
-def test_bracket_isotope_shape_mismatch(ini_default):
+def test_iso_bracket_shape_mismatch(ini_default):
     """Raise Value error on shape mismatch between nd arrays."""
     with pytest.raises(ValueError) as err_info:
-        ini_default.bracket_isotope(["Ne-21", "Mg-25"], "Si", 33)
+        ini_default.iso_bracket(["Ne-21", "Mg-25"], "Si", 33)
     err_msg = err_info.value.args[0]
     assert (
         err_msg == "Length of requested isotope ratios does not match length of "
@@ -174,26 +174,26 @@ def test_bracket_isotope_shape_mismatch(ini_default):
     value=st.floats(min_value=0, exclude_min=True, max_value=1e6),
     factor=st.floats(min_value=0, exclude_min=True, max_value=1e9),
 )
-def test_delta_element(ini_default, ele1, ele2, value, factor):
+def test_ele_delta(ini_default, ele1, ele2, value, factor):
     """Calculate delta-value for an element ratio in various units."""
     # default factor = 1000
     val_exp = (
         value / (ini_default.ele_dict[ele1][0] / ini_default.ele_dict[ele2][0]) - 1
     ) * 1000
-    val_get = ini_default.delta_element(ele1, ele2, value)
+    val_get = ini_default.ele_delta(ele1, ele2, value)
     assert val_get == val_exp
     # with a factor
     val_exp_fct = (
         value / (ini_default.ele_dict[ele1][0] / ini_default.ele_dict[ele2][0]) - 1
     ) * factor
-    val_get_fct = ini_default.delta_element(ele1, ele2, value, delta_factor=factor)
+    val_get_fct = ini_default.ele_delta(ele1, ele2, value, delta_factor=factor)
     assert val_get_fct == val_exp_fct
 
 
-def test_delta_element_shape_mismatch(ini_default):
+def test_ele_delta_shape_mismatch(ini_default):
     """Raise a ValueError on shape mismatch between nd arrays."""
     with pytest.raises(ValueError) as err_info:
-        ini_default.delta_element("Ne", "Si", [0.07, 0.09], delta_factor=10000)
+        ini_default.ele_delta("Ne", "Si", [0.07, 0.09], delta_factor=10000)
     err_msg = err_info.value.args[0]
     assert (
         err_msg == "Length of requested element ratios does not match length of "
@@ -207,27 +207,27 @@ def test_delta_element_shape_mismatch(ini_default):
     value=st.floats(min_value=0, exclude_min=True, max_value=1e6),
     factor=st.floats(min_value=0, exclude_min=True, max_value=1e9),
 )
-def test_delta_isotope(ini_default, iso1, iso2, value, factor):
+def test_iso_delta(ini_default, iso1, iso2, value, factor):
     """Calculate delta-value for an isotope ratio."""
     # default factor = 1000
     val_exp = (
         value / (ini_default.iso_dict[iso1][1] / ini_default.iso_dict[iso2][1]) - 1
     ) * 1000
-    val_get = ini_default.delta_isotope(iso1, iso2, value)
+    val_get = ini_default.iso_delta(iso1, iso2, value)
     assert val_get == val_exp
     # with a factor
     # fixme next line can be simplified by just adjusting val_exp / 1000 * factor
     val_exp_fct = (
         value / (ini_default.iso_dict[iso1][1] / ini_default.iso_dict[iso2][1]) - 1
     ) * factor
-    val_get_fct = ini_default.delta_isotope(iso1, iso2, value, delta_factor=factor)
+    val_get_fct = ini_default.iso_delta(iso1, iso2, value, delta_factor=factor)
     assert val_get_fct == val_exp_fct
 
 
-def test_delta_isotope_shape_mismatch(ini_default):
+def test_iso_delta_shape_mismatch(ini_default):
     """Raise a ValueError on shape mismatch between the ndarrays."""
     with pytest.raises(ValueError) as err_info:
-        ini_default.delta_isotope("Ne-22", "Ne-20", [0.07, 0.09], delta_factor=10000)
+        ini_default.iso_delta("Ne-22", "Ne-20", [0.07, 0.09], delta_factor=10000)
     err_msg = err_info.value.args[0]
     assert (
         err_msg == "Length of requested isotope ratios does not match length of "
@@ -242,32 +242,32 @@ def test_delta_isotope_shape_mismatch(ini_default):
     ele1=st.sampled_from(list(data.lodders09_elements.keys())),
     ele2=st.sampled_from(list(data.lodders09_elements.keys())),
 )
-def test_ratio_element_ele_ele(ini_default, ele1, ele2):
+def test_ele_ratio_ele_ele(ini_default, ele1, ele2):
     """Calculate element ratio for element vs. element."""
     val_exp = ini_default.ele_dict[ele1][0] / ini_default.ele_dict[ele2][0]
-    assert ini_default.ratio_element(ele1, ele2) == val_exp
+    assert ini_default.ele_ratio(ele1, ele2) == val_exp
 
 
 @given(
     ele1=st.sampled_from(list(data.lodders09_elements.keys())),
     ele2=st.sampled_from(list(data.lodders09_elements.keys())),
 )
-def test_ratio_element_ele_ele_nist_db(ini_nist, ele1, ele2):
+def test_ele_ratio_ele_ele_nist_db(ini_nist, ele1, ele2):
     """Calculate element ratio when not a number."""
-    assert np.isnan(ini_nist.ratio_element(ele1, ele2))
+    assert np.isnan(ini_nist.ele_ratio(ele1, ele2))
 
 
 @given(
     ele1=st.sampled_from(list(data.lodders09_elements.keys())),
     ele2=st.sampled_from(list(data.lodders09_elements.keys())),
 )
-def test_ratio_element_ele_ele_from_log(ele1, ele2):
+def test_ele_ratio_ele_ele_from_log(ele1, ele2):
     """Calculate element ratio for element vs. element."""
     ini = iniabu.IniAbu()
     val_exp = ini.ele_dict[ele1][0] / ini.ele_dict[ele2][0]
     ini.unit = "num_log"
-    assert ini.ratio_element(ele1, ele2) == val_exp
-    assert ini.ratio_element(ele1, ele2, mass_fraction=False) == val_exp
+    assert ini.ele_ratio(ele1, ele2) == val_exp
+    assert ini.ele_ratio(ele1, ele2, mass_fraction=False) == val_exp
 
 
 @given(
@@ -275,7 +275,7 @@ def test_ratio_element_ele_ele_from_log(ele1, ele2):
     ele2=st.sampled_from(list(data.lodders09_elements.keys())),
     ele3=st.sampled_from(list(data.lodders09_elements.keys())),
 )
-def test_ratio_element_eles_ele(ini_default, ele1, ele2, ele3):
+def test_ele_ratio_eles_ele(ini_default, ele1, ele2, ele3):
     """Calculate element ratio for elements vs. element."""
     val_exp = np.array(
         [
@@ -283,7 +283,7 @@ def test_ratio_element_eles_ele(ini_default, ele1, ele2, ele3):
             ini_default.ele_dict[ele2][0] / ini_default.ele_dict[ele3][0],
         ]
     )
-    np.testing.assert_equal(ini_default.ratio_element([ele1, ele2], ele3), val_exp)
+    np.testing.assert_equal(ini_default.ele_ratio([ele1, ele2], ele3), val_exp)
 
 
 @given(
@@ -292,7 +292,7 @@ def test_ratio_element_eles_ele(ini_default, ele1, ele2, ele3):
     ele3=st.sampled_from(list(data.lodders09_elements.keys())),
     ele4=st.sampled_from(list(data.lodders09_elements.keys())),
 )
-def test_ratio_element_eles_eles(ini_default, ele1, ele2, ele3, ele4):
+def test_ele_ratio_eles_eles(ini_default, ele1, ele2, ele3, ele4):
     """Calculate element ratio for elements vs. elements."""
     val_exp = np.array(
         [
@@ -300,15 +300,13 @@ def test_ratio_element_eles_eles(ini_default, ele1, ele2, ele3, ele4):
             ini_default.ele_dict[ele2][0] / ini_default.ele_dict[ele4][0],
         ]
     )
-    np.testing.assert_equal(
-        ini_default.ratio_element([ele1, ele2], [ele3, ele4]), val_exp
-    )
+    np.testing.assert_equal(ini_default.ele_ratio([ele1, ele2], [ele3, ele4]), val_exp)
 
 
-def test_ratio_element_ele_eles_length_mismatch(ini_default):
+def test_ele_ratio_ele_eles_length_mismatch(ini_default):
     """Raise a ValueError if denominator has different length from nominator."""
     with pytest.raises(ValueError) as err_info:
-        ini_default.ratio_element("H", ["H", "Si"])
+        ini_default.ele_ratio("H", ["H", "Si"])
     err_msg = err_info.value.args[0]
     assert (
         err_msg == "The denominator contains more than one entry but has a "
@@ -320,14 +318,14 @@ def test_ratio_element_ele_eles_length_mismatch(ini_default):
     ele1=st.sampled_from(list(data.lodders09_elements.keys())),
     ele2=st.sampled_from(list(data.lodders09_elements.keys())),
 )
-def test_ratio_element_ele_ele_mass_fraction_true(ini_default, ele1, ele2):
+def test_ele_ratio_ele_ele_mass_fraction_true(ini_default, ele1, ele2):
     """Calculate element ratio for num values in mass fraction."""
     val_exp = (
         ini_default.ele_dict[ele1][0]
         * data.elements_mass[ele1]
         / (ini_default.ele_dict[ele2][0] * data.elements_mass[ele2])
     )
-    assert ini_default.ratio_element(ele1, ele2, mass_fraction=True) == pytest.approx(
+    assert ini_default.ele_ratio(ele1, ele2, mass_fraction=True) == pytest.approx(
         val_exp
     )
 
@@ -336,27 +334,21 @@ def test_ratio_element_ele_ele_mass_fraction_true(ini_default, ele1, ele2):
     ele1=st.sampled_from(list(data.lodders09_elements.keys())),
     ele2=st.sampled_from(list(data.lodders09_elements.keys())),
 )
-def test_ratio_element_ele_ele_mf_notation_mf(ini_mf, ele1, ele2):
+def test_ele_ratio_ele_ele_mf_notation_mf(ini_mf, ele1, ele2):
     """Calculate element ratio in mass_fraction with mass fraction notation."""
     val_exp = ini_mf.ele_dict_mf[ele1][0] / ini_mf.ele_dict_mf[ele2][0]
-    assert ini_mf.ratio_element(ele1, ele2, mass_fraction=True) == pytest.approx(
-        val_exp
-    )
-    assert ini_mf.ratio_element(ele1, ele2, mass_fraction=None) == pytest.approx(
-        val_exp
-    )
+    assert ini_mf.ele_ratio(ele1, ele2, mass_fraction=True) == pytest.approx(val_exp)
+    assert ini_mf.ele_ratio(ele1, ele2, mass_fraction=None) == pytest.approx(val_exp)
 
 
 @given(
     ele1=st.sampled_from(list(data.lodders09_elements.keys())),
     ele2=st.sampled_from(list(data.lodders09_elements.keys())),
 )
-def test_ratio_element_ele_ele_mf_notation_no_mf(ini_mf, ini_default, ele1, ele2):
+def test_ele_ratio_ele_ele_mf_notation_no_mf(ini_mf, ini_default, ele1, ele2):
     """Calculate element ratio for element vs. element in mass fraction notation."""
     val_exp = ini_default.ele_dict[ele1][0] / ini_default.ele_dict[ele2][0]
-    assert ini_mf.ratio_element(ele1, ele2, mass_fraction=False) == pytest.approx(
-        val_exp
-    )
+    assert ini_mf.ele_ratio(ele1, ele2, mass_fraction=False) == pytest.approx(val_exp)
 
 
 # RATIOS ISOTOPES #
@@ -366,22 +358,22 @@ def test_ratio_element_ele_ele_mf_notation_no_mf(ini_mf, ini_default, ele1, ele2
     iso1=st.sampled_from(list(data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(data.lodders09_isotopes.keys())),
 )
-def test_ratio_isotope_iso_iso(ini_default, iso1, iso2):
+def test_iso_ratio_iso_iso(ini_default, iso1, iso2):
     """Calculate isotope ratio for one nominator and one denominator isotope."""
     val_exp = ini_default.iso_dict[iso1][1] / ini_default.iso_dict[iso2][1]
-    assert ini_default.ratio_isotope(iso1, iso2) == val_exp
+    assert ini_default.iso_ratio(iso1, iso2) == val_exp
 
 
 @given(
     iso1=st.sampled_from(list(data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(data.lodders09_isotopes.keys())),
 )
-def test_ratio_isotope_iso_iso_from_log(iso1, iso2):
+def test_iso_ratio_iso_iso_from_log(iso1, iso2):
     """Calculate isotope ratio when database is in logarithmic state."""
     ini = iniabu.IniAbu()
     val_exp = ini.iso_dict[iso1][1] / ini.iso_dict[iso2][1]
     ini.unit = "num_log"
-    assert ini.ratio_isotope(iso1, iso2) == val_exp
+    assert ini.iso_ratio(iso1, iso2) == val_exp
 
 
 @given(
@@ -389,7 +381,7 @@ def test_ratio_isotope_iso_iso_from_log(iso1, iso2):
     iso2=st.sampled_from(list(data.lodders09_isotopes.keys())),
     iso3=st.sampled_from(list(data.lodders09_isotopes.keys())),
 )
-def test_ratio_isotope_isos_iso(ini_default, iso1, iso2, iso3):
+def test_iso_ratio_isos_iso(ini_default, iso1, iso2, iso3):
     """Calculate isotope ratio for several nominators and one denominator isotope."""
     val_exp = np.array(
         [
@@ -397,7 +389,7 @@ def test_ratio_isotope_isos_iso(ini_default, iso1, iso2, iso3):
             ini_default.iso_dict[iso2][1] / ini_default.iso_dict[iso3][1],
         ]
     )
-    np.testing.assert_equal(ini_default.ratio_isotope([iso1, iso2], iso3), val_exp)
+    np.testing.assert_equal(ini_default.iso_ratio([iso1, iso2], iso3), val_exp)
 
 
 @given(
@@ -406,7 +398,7 @@ def test_ratio_isotope_isos_iso(ini_default, iso1, iso2, iso3):
     iso3=st.sampled_from(list(data.lodders09_isotopes.keys())),
     iso4=st.sampled_from(list(data.lodders09_isotopes.keys())),
 )
-def test_ratio_isotope_isos_isos(ini_default, iso1, iso2, iso3, iso4):
+def test_iso_ratio_isos_isos(ini_default, iso1, iso2, iso3, iso4):
     """Calculate isotope ratios for several nominators and denominators."""
     val_exp = np.array(
         [
@@ -414,15 +406,13 @@ def test_ratio_isotope_isos_isos(ini_default, iso1, iso2, iso3, iso4):
             ini_default.iso_dict[iso2][1] / ini_default.iso_dict[iso4][1],
         ]
     )
-    np.testing.assert_equal(
-        ini_default.ratio_isotope([iso1, iso2], [iso3, iso4]), val_exp
-    )
+    np.testing.assert_equal(ini_default.iso_ratio([iso1, iso2], [iso3, iso4]), val_exp)
 
 
-def test_ratio_isotope_isos_isos_length_mismatch(ini_default):
+def test_iso_ratio_isos_isos_length_mismatch(ini_default):
     """Raise a ValueError if nominator and denominator have different lengths."""
     with pytest.raises(ValueError) as err_info:
-        ini_default.ratio_isotope(["Ne-21", "Ne-22"], ["Ne-20", "Ne-21", "Ne-22"])
+        ini_default.iso_ratio(["Ne-21", "Ne-22"], ["Ne-20", "Ne-21", "Ne-22"])
     err_msg = err_info.value.args[0]
     assert (
         err_msg == "The denominator contains more than one entry but has a "
@@ -434,20 +424,20 @@ def test_ratio_isotope_isos_isos_length_mismatch(ini_default):
     ele1=st.sampled_from(list(data.lodders09_elements.keys())),
     iso2=st.sampled_from(list(data.lodders09_isotopes.keys())),
 )
-def test_ratio_isotope_ele_iso(ini_default, ele1, iso2):
+def test_iso_ratio_ele_iso(ini_default, ele1, iso2):
     """Calculae isotope ratios for all isotopes of an element versus one isotope."""
-    all_isos = ini_default._get_all_isotopes(ele1)
+    all_isos = ini_default._get_all_isos(ele1)
     val_exp = np.empty(len(all_isos))
     for it, iso in enumerate(all_isos):
         val_exp[it] = ini_default.iso_dict[iso][1] / ini_default.iso_dict[iso2][1]
-    np.testing.assert_equal(ini_default.ratio_isotope(ele1, iso2), val_exp)
+    np.testing.assert_equal(ini_default.iso_ratio(ele1, iso2), val_exp)
 
 
 @given(
     iso1=st.sampled_from(list(data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(data.lodders09_isotopes.keys())),
 )
-def test_ratio_isotope_iso_iso_mass_fraction_true(ini_default, iso1, iso2):
+def test_iso_ratio_iso_iso_mass_fraction_true(ini_default, iso1, iso2):
     """Calculate isotope ratio as mass fraction from num_lin units."""
     val_exp = (
         ini_default.iso_dict[iso1][1]
@@ -455,7 +445,7 @@ def test_ratio_isotope_iso_iso_mass_fraction_true(ini_default, iso1, iso2):
         / (ini_default.iso_dict[iso2][1] * data.isotopes_mass[iso2])
     )
     np.testing.assert_allclose(
-        ini_default.ratio_isotope(iso1, iso2, mass_fraction=True), val_exp
+        ini_default.iso_ratio(iso1, iso2, mass_fraction=True), val_exp
     )
 
 
@@ -463,14 +453,14 @@ def test_ratio_isotope_iso_iso_mass_fraction_true(ini_default, iso1, iso2):
     iso1=st.sampled_from(list(data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(data.lodders09_isotopes.keys())),
 )
-def test_ratio_isotope_iso_iso_mf_mass_fraction(ini_mf, iso1, iso2):
+def test_iso_ratio_iso_iso_mf_mass_fraction(ini_mf, iso1, iso2):
     """Calculate isotope ratio as mass fraction from mass_fraction units."""
     val_exp = ini_mf.iso_dict_mf[iso1][1] / ini_mf.iso_dict_mf[iso2][1]
     np.testing.assert_allclose(
-        ini_mf.ratio_isotope(iso1, iso2, mass_fraction=True), val_exp
+        ini_mf.iso_ratio(iso1, iso2, mass_fraction=True), val_exp
     )
     np.testing.assert_allclose(
-        ini_mf.ratio_isotope(iso1, iso2, mass_fraction=None), val_exp
+        ini_mf.iso_ratio(iso1, iso2, mass_fraction=None), val_exp
     )
 
 
@@ -478,11 +468,11 @@ def test_ratio_isotope_iso_iso_mf_mass_fraction(ini_mf, iso1, iso2):
     iso1=st.sampled_from(list(data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(data.lodders09_isotopes.keys())),
 )
-def test_ratio_isotope_iso_iso_mf_num_fraction(ini_mf, iso1, iso2):
+def test_iso_ratio_iso_iso_mf_num_fraction(ini_mf, iso1, iso2):
     """Calculate isotope ratio as number fraction from mass_fraction units."""
     val_exp = ini_mf.iso_dict[iso1][1] / ini_mf.iso_dict[iso2][1]
     np.testing.assert_allclose(
-        ini_mf.ratio_isotope(iso1, iso2, mass_fraction=False), val_exp
+        ini_mf.iso_ratio(iso1, iso2, mass_fraction=False), val_exp
     )
 
 
@@ -491,9 +481,9 @@ def test_ratio_isotope_iso_iso_mf_num_fraction(ini_mf, iso1, iso2):
     iso2=st.sampled_from(list(data.lodders09_isotopes.keys())),
     ele=st.sampled_from(list(data.lodders09_elements.keys())),
 )
-def test_ratio_isotope_isos_ele_mass_fraction_true(ini_default, iso1, iso2, ele):
+def test_iso_ratio_isos_ele_mass_fraction_true(ini_default, iso1, iso2, ele):
     """Calculate isotope ratios as mass fraction from num_lin units."""
-    iso_denominator = ini_default._get_major_isotope(ele)
+    iso_denominator = ini_default._get_major_iso(ele)
     val_exp = np.array(
         [
             ini_default.iso_dict[iso1][1]
@@ -510,7 +500,7 @@ def test_ratio_isotope_isos_ele_mass_fraction_true(ini_default, iso1, iso2, ele)
             ),
         ]
     )
-    val_get = ini_default.ratio_isotope([iso1, iso2], ele, mass_fraction=True)
+    val_get = ini_default.iso_ratio([iso1, iso2], ele, mass_fraction=True)
     np.testing.assert_allclose(val_get, val_exp)
 
 
@@ -518,28 +508,28 @@ def test_ratio_isotope_isos_ele_mass_fraction_true(ini_default, iso1, iso2, ele)
     iso=st.sampled_from(list(data.lodders09_isotopes.keys())),
     ele=st.sampled_from(list(data.lodders09_elements.keys())),
 )
-def test_ratio_isotope_iso_ele(ini_default, iso, ele):
+def test_iso_ratio_iso_ele(ini_default, iso, ele):
     """Calculate isotope ratio for one isotope and an element (i.e., major isotope)."""
-    iso_denominator = ini_default._get_major_isotope(ele)
+    iso_denominator = ini_default._get_major_iso(ele)
     val_exp = ini_default.iso_dict[iso][1] / ini_default.iso_dict[iso_denominator][1]
-    assert ini_default.ratio_isotope(iso, ele) == val_exp
+    assert ini_default.iso_ratio(iso, ele) == val_exp
 
 
 # PRIVATE ROUTINES
 
 
 @given(ele=st.sampled_from(list(data.lodders09_elements.keys())))
-def test_get_all_isotopes(ini_default, ele):
+def test_get_all_isos(ini_default, ele):
     """Ensure appropriate isotope list is returned for a given element."""
     iso_list = []
     for iso in ini_default.ele_dict[ele][1]:
         iso_list.append(f"{ele}-{iso}")
-    assert ini_default._get_all_isotopes(ele) == iso_list
+    assert ini_default._get_all_isos(ele) == iso_list
 
 
 @given(ele=st.sampled_from(list(data.lodders09_elements.keys())))
-def test_get_major_isotope(ini_default, ele):
+def test_get_major_iso(ini_default, ele):
     """Ensure that the correct major isotope is returned."""
     index = np.array(ini_default.ele_dict[ele][2]).argmax()
     maj_iso = f"{ele}-{ini_default.ele_dict[ele][1][index]}"
-    assert ini_default._get_major_isotope(ele) == maj_iso
+    assert ini_default._get_major_iso(ele) == maj_iso

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -12,9 +12,9 @@ import iniabu.elements
 import iniabu.utilities
 from iniabu.utilities import (
     linear_units,
-    make_isotope_dictionary,
-    make_log_abundance_dictionaries,
-    make_mass_fraction_dictionary,
+    make_iso_dict,
+    make_log_abu_dict,
+    make_mf_dict,
     return_as_ndarray,
     return_list_simplifier,
     return_string_as_list,
@@ -26,7 +26,7 @@ def test_proxy_list_index_error(ini_default):
     # entry not in list
     item = "invalid"
     with pytest.raises(IndexError) as err_info:
-        ini_default.element[item]
+        ini_default.ele[item]
     err_msg = err_info.value.args[0]
     assert (
         err_msg
@@ -43,13 +43,13 @@ def test_proxy_list_tuple_initialization(ini_default):
     for it, ele in enumerate(elements):
         val_exp[it] = iniabu.data.lodders09_elements[ele][0]
     # result from routine to be tested
-    val_get = ini_default.element[elements].solar_abundance
+    val_get = ini_default.ele[elements].abu_solar
     np.testing.assert_equal(val_exp, val_get)
 
 
 def test_proxy_list_generator(ini_default):
     """Test that generator of ProxyList returns the correct object type."""
-    gen = ini_default.element.__iter__()
+    gen = ini_default.ele.__iter__()
     val = next(gen)
     assert isinstance(val, iniabu.elements.Elements)
 
@@ -58,7 +58,7 @@ def test_proxy_list_length(ini_default):
     """Test that length of the ProxyList."""
     # test proxy list length
     length = len(ini_default.ele_dict.keys())
-    assert ini.element.__len__() == length
+    assert ini.ele.__len__() == length
 
 
 # FUNCTIONS #
@@ -90,7 +90,7 @@ def test_linear_units_no_switch(ini_default, ini_mf):
 
 
 @given(abu_x=st.floats(min_value=0.001, allow_infinity=False))
-def test_make_isotope_dictionary(abu_x):
+def test_make_iso_dict(abu_x):
     """Create an isotope dictionary form an elementary dictionary."""
     ele_dict = {
         "H": [10000.0, [1, 2], [0.8, 0.2], [8000.0, 2000.0]],
@@ -101,18 +101,18 @@ def test_make_isotope_dictionary(abu_x):
         "H-2": [0.2, 2000.0],
         "X-10": [1.0, abu_x],
     }
-    assert make_isotope_dictionary(ele_dict) == iso_dict_expected
+    assert make_iso_dict(ele_dict) == iso_dict_expected
 
 
 @given(abu_x=st.floats(min_value=0.001, allow_infinity=False))
-def test_make_log_abundance_dictionaries(abu_x):
+def test_make_log_abu_dict(abu_x):
     """Ensure that logarithmic abundance dictionaries are made in correct form."""
     ele_dict_lin = {
         "H": [10000.0, [1, 2], [0.8, 0.2], [8000.0, 2000.0]],
         "X": [abu_x, [10], [1.0], [abu_x]],
     }
     # get logarithmic dictionaries
-    ele_dict_log, iso_dict_log = make_log_abundance_dictionaries(ele_dict_lin)
+    ele_dict_log, iso_dict_log = make_log_abu_dict(ele_dict_lin)
     # assert elements
     abu_h = ele_dict_lin["H"][0]
     assert ele_dict_log["H"][0] == 12.0
@@ -125,7 +125,7 @@ def test_make_log_abundance_dictionaries(abu_x):
     assert iso_dict_log["X-10"][1] == np.log10(abu_x / abu_h) + 12.0
 
 
-def test_make_mass_fraction_dictionaries():
+def test_make_mf_dict():
     """Ensure that mass fraction dictionaries are made in correct form."""
     ele_dict = {
         "H": [10000.0, [1, 2], [0.8, 0.2], [8000.0, 2000.0]],
@@ -165,9 +165,9 @@ def test_make_mass_fraction_dictionaries():
         for it, mf_abu_iso in enumerate(ele_dict_expected[ele][3]):
             ele_dict_expected[ele][2][it] = mf_abu_iso / mf_abu_sum
     # isotope dict expected
-    iso_dict_expected = make_isotope_dictionary(ele_dict_expected)
+    iso_dict_expected = make_iso_dict(ele_dict_expected)
     # test
-    ele_dict_gotten, iso_dict_gotten = make_mass_fraction_dictionary(ele_dict)
+    ele_dict_gotten, iso_dict_gotten = make_mf_dict(ele_dict)
     assert ele_dict_gotten == ele_dict_expected
     assert iso_dict_gotten == iso_dict_expected
 
@@ -184,7 +184,7 @@ def test_make_mass_fraction_dictionary_iso_relative_abundances(ini_default, ele)
     assert sum(ini_default.ele_dict_mf[ele][2]) == pytest.approx(1.0)
 
 
-def test_make_mass_fraction_dictionaries_ele_dict_untouched():
+def test_make_mf_dict_ele_dict_untouched():
     """Ensure that mass_fraction_dictionary routine does not overwrite input.
 
     This simply makes sure that a deepcopy is made and not just a simple copy for the
@@ -197,7 +197,7 @@ def test_make_mass_fraction_dictionaries_ele_dict_untouched():
     }
     ele_dict_backup = copy.deepcopy(ele_dict)
     # run the routine
-    _ = make_mass_fraction_dictionary(ele_dict)
+    _ = make_mf_dict(ele_dict)
     assert ele_dict == ele_dict_backup
 
 


### PR DESCRIPTION
**Refactored functions**:

- element -> ele
- isotope -> iso
- solar_abundance -> abu_solar
- relative_abundance -> abu_rel
- isotopes_relative_abundance -> iso_abu_rel
- isotopes_solar_abundance -> iso_abu_sol
- isotopes_z -> iso_z
- bracket_element -> ele_bracket
- bracket_isotope -> iso_bracket
- delta_element -> ele_delta
- delta_isotope -> iso_delta
- ratio_element -> ele_ratio
- ratio_isotope -> iso_ratio
- make_isotope_dictionary -> make_iso_dict
- make_log_abundance_dictionary -> make_log_abu_dict
- make_mass_fraction_dictionary -> make_mf_dict

Renamed associated tests as well.

Also added missing functions in `utilities.py` to API documentation.