### PR TITLE
Allow single delta-, bracket-ratio for many values

### DIFF
--- a/iniabu/main.py
+++ b/iniabu/main.py
@@ -299,7 +299,10 @@ class IniAbu(object):
 
         Nominator and denominator have the same restrictions as for the
         ``ele_ratio`` method.
-        The same number of values must be supplied as there are element ratios defined.
+        If one element ratio is defined but multiple values, the isotope ratio for
+        all values is calculated and returned as a numpy array. If more than one element
+        ratio is defined, the same number of values must be supplied as there are
+        element ratios defined.
 
         :param nominator: Element(s) in nominator.
         :type nominator: str,list
@@ -330,7 +333,7 @@ class IniAbu(object):
         )
         value = return_as_ndarray(value)
 
-        if solar_ratios.shape != value.shape:
+        if solar_ratios.shape != value.shape and solar_ratios.shape != ():
             raise ValueError(
                 "Length of requested element ratios does not match length of "
                 "provided values."
@@ -347,7 +350,10 @@ class IniAbu(object):
 
         Nominator and denominator have the same restrictions as for the
         ``ele_ratio`` method.
-        The same number of values must be supplied as there are element ratios defined.
+        If one isotope ratio is defined but multiple values, the isotope ratio for
+        all values is calculated and returned as a numpy array. If more than one isotope
+        ratio is defined, the same number of values must be supplied as there are
+        isotope ratios defined.
 
         :param nominator: Isotope(s) in nominator.
         :type nominator: str,list
@@ -378,7 +384,7 @@ class IniAbu(object):
         )
         value = return_as_ndarray(value)
 
-        if solar_ratios.shape != value.shape:
+        if solar_ratios.shape != value.shape and solar_ratios.shape != ():
             raise ValueError(
                 "Length of requested isotope ratios does not match length of "
                 "provided values."
@@ -400,7 +406,10 @@ class IniAbu(object):
 
         Nominator and denominator have the same restrictions as for the
         ``ele_ratio`` method.
-        The same number of values must be supplied as there are element ratios defined.
+        If one element ratio is defined but multiple values, the isotope ratio for
+        all values is calculated and returned as a numpy array. If more than one element
+        ratio is defined, the same number of values must be supplied as there are
+        element ratios defined.
 
         :param nominator: Element(s) in nominator.
         :type nominator: str,list
@@ -435,7 +444,7 @@ class IniAbu(object):
         )
         value = return_as_ndarray(value)
 
-        if solar_ratios.shape != value.shape:
+        if solar_ratios.shape != value.shape and solar_ratios.shape != ():
             raise ValueError(
                 "Length of requested element ratios does not match length of "
                 "provided values."
@@ -457,7 +466,10 @@ class IniAbu(object):
 
         Nominator and denominator have the same restrictions as for the
         ``ele_ratio`` method.
-        The same number of values must be supplied as there are isotope ratios defined.
+        If one isotope ratio is defined but multiple values, the isotope ratio for
+        all values is calculated and returned as a numpy array. If more than one isotope
+        ratio is defined, the same number of values must be supplied as there are
+        isotope ratios defined.
 
         :param nominator: Isotope(s) in nominator.
         :type nominator: str,list
@@ -498,7 +510,7 @@ class IniAbu(object):
         )
         value = return_as_ndarray(value)
 
-        if solar_ratios.shape != value.shape:
+        if solar_ratios.shape != value.shape and solar_ratios.shape != ():
             raise ValueError(
                 "Length of requested isotope ratios does not match length of "
                 "provided values."

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -143,6 +143,24 @@ def test_ele_bracket_shape_mismatch(ini_default):
     )
 
 
+def test_ele_bracket_many_values(ini_default):
+    """Calculate element delta-values for many given measurements / model values."""
+    ele1 = "Si"
+    ele2 = "Ne"
+    # "measured / modeled" values
+    values = np.array([0.1, 0.2, 0.3])
+    val_expected = np.log10(values) - np.log10(
+        ini_default.ele_dict[ele1][0] / ini_default.ele_dict[ele2][0]
+    )
+
+    np.testing.assert_array_almost_equal(
+        ini_default.ele_bracket(ele1, ele2, values), val_expected
+    )
+
+
+# ISOTOPE BRACKET #
+
+
 @given(
     iso1=st.sampled_from(list(data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(data.lodders09_isotopes.keys())),
@@ -168,6 +186,24 @@ def test_iso_bracket_shape_mismatch(ini_default):
     )
 
 
+def test_iso_bracket_many_values(ini_default):
+    """Calculate bracket-values for many given measurements / model isotope values."""
+    iso1 = "Si-29"
+    iso2 = "Si-28"
+    # "measured / modeled" values
+    values = np.array([0.1, 0.2, 0.3])
+    val_expected = np.log10(values) - np.log10(
+        ini_default.iso_dict[iso1][1] / ini_default.iso_dict[iso2][1]
+    )
+
+    np.testing.assert_array_almost_equal(
+        ini_default.iso_bracket(iso1, iso2, values), val_expected
+    )
+
+
+# ELEMENT DELTA #
+
+
 @given(
     ele1=st.sampled_from(list(data.lodders09_elements.keys())),
     ele2=st.sampled_from(list(data.lodders09_elements.keys())),
@@ -191,14 +227,33 @@ def test_ele_delta(ini_default, ele1, ele2, value, factor):
 
 
 def test_ele_delta_shape_mismatch(ini_default):
-    """Raise a ValueError on shape mismatch between nd arrays."""
+    """Raise a ValueError on shape mismatch between nd arrays if more than one ratio."""
     with pytest.raises(ValueError) as err_info:
-        ini_default.ele_delta("Ne", "Si", [0.07, 0.09], delta_factor=10000)
+        ini_default.ele_delta(
+            ["He", "Ne"], "Si", [0.07, 0.08, 0.09], delta_factor=10000
+        )
     err_msg = err_info.value.args[0]
     assert (
         err_msg == "Length of requested element ratios does not match length of "
         "provided values."
     )
+
+
+def test_ele_delta_many_values(ini_default):
+    """Calculate element delta-values for many given measurements / model values."""
+    ele1 = "Si"
+    ele2 = "Ne"
+    # "measured / modeled" values
+    values = np.array([0.1, 0.2, 0.3])
+    val_expected = (
+        values / (ini_default.ele_dict[ele1][0] / ini_default.ele_dict[ele2][0]) - 1
+    ) * 1000.0
+    np.testing.assert_array_almost_equal(
+        ini_default.ele_delta(ele1, ele2, values), val_expected
+    )
+
+
+# ISOTOPE DELTA #
 
 
 @given(
@@ -227,11 +282,25 @@ def test_iso_delta(ini_default, iso1, iso2, value, factor):
 def test_iso_delta_shape_mismatch(ini_default):
     """Raise a ValueError on shape mismatch between the ndarrays."""
     with pytest.raises(ValueError) as err_info:
-        ini_default.iso_delta("Ne-22", "Ne-20", [0.07, 0.09], delta_factor=10000)
+        ini_default.iso_delta("Ne", "Ne-20", [0.07, 0.09], delta_factor=10000)
     err_msg = err_info.value.args[0]
     assert (
         err_msg == "Length of requested isotope ratios does not match length of "
         "provided values."
+    )
+
+
+def test_iso_delta_many_values(ini_default):
+    """Calculate delta-values for many given measurements / model values."""
+    iso1 = "Si-29"
+    iso2 = "Si-28"
+    # "measured / modeled" values
+    values = np.array([0.1, 0.2, 0.3])
+    val_expected = (
+        values / (ini_default.iso_dict[iso1][1] / ini_default.iso_dict[iso2][1]) - 1
+    ) * 1000.0
+    np.testing.assert_array_almost_equal(
+        ini_default.iso_delta(iso1, iso2, values), val_expected
     )
 
 


### PR DESCRIPTION
If only one isotope ratio is requested, but many values (e.g., a whole
model set) are given, then a numpy array with all values ratioed to that
one isotope ratio is returned. This is, e.g., useful to calculate
delta-values for a whole vector of (GCE, ...) models.