### PR TITLE
Fix GitHub Actions to not run on forks, e.g., nugrid when pushing

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   analyze:
+    if: github.repository_owner == 'galactic-forensics'
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/package_testing.yml
+++ b/.github/workflows/package_testing.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   # Build and test
   build:
-
+    if: github.repository_owner == 'galactic-forensics'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   deploy:
-
+    if: github.repository_owner == 'galactic-forensics'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- Avoid GitHub Actions to run on other repos and fail because of missing secrets