### PR TITLE
Isotope & element names, query all isotopes of a given element

### DIFF
--- a/docs/api/utilities.rst
+++ b/docs/api/utilities.rst
@@ -12,6 +12,12 @@ Utility classes and functions
     :undoc-members:
 
 
+:func:`get_all_isos`
+--------------------
+
+.. autofunction:: get_all_isos
+
+
 :func:`linear_units`
 --------------------
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -261,6 +261,10 @@ can be loaded into a variable as following:
 The following properties can now be queried
 from the element:
 
+- The name of an element,
+  which just returns that same abbreviation
+  used to call the element,
+  can be queried with ``name``.
 - The mass of the element,
   calculated using the isotope masses
   and the currently loaded abundances,
@@ -285,13 +289,17 @@ one could run the following statement:
    >>> ele.abu_solar
    847990.0
 
+.. note:: You can query multiple elements as once.
+  To do so,
+  simply pass a list of the elements
+  to be queried.
 
 
 Querying an isotope
 ~~~~~~~~~~~~~~~~~~~
 
 To query an isotope's properties
-with respect to teh solar abundance,
+with respect to the solar abundance,
 it can be loaded into a temporary variable,
 similar to when loading an element.
 For example:
@@ -306,6 +314,8 @@ as following:
 The following properties can then
 be queried from this isotope:
 
+- The name of the isotope(s) requested
+  can be queried with ``name``.
 - The mass of a specific isotope using ``mass``.
 - The solar abundance of the isotope itself using ``abu_solar``,
   normed as discussed above
@@ -330,6 +340,22 @@ one could run the following two commands in python:
   >>> iso.abu_rel
   0.058449999999999995
 
+
+.. note:: To query all isotopes of an element,
+  you can query the isotope as following:
+
+  .. code-block:: python
+
+    >>> iso = ini.iso["Ne"]
+    >>> iso.name
+    ['Ne-20', 'Ne-21', 'Ne-22']
+
+
+.. note:: You can query multiple isotopes at once.
+  To do so,
+  simply pass a list of the isotopes
+  (or even elements in case of all isotopes)
+  to be queried.
 
 Element and isotope ratios
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/iniabu/elements.py
+++ b/iniabu/elements.py
@@ -152,3 +152,12 @@ class Elements(object):
             ret_arr.append(np.sum(isos_abu * isos_mass))
         ret_arr = np.array(ret_arr)
         return return_list_simplifier(ret_arr)
+
+    @property
+    def name(self):
+        """Get the name of an element.
+
+        :return: Name of the set element(s).
+        :rtype: str, list(str)
+        """
+        return return_list_simplifier(self._eles)

--- a/iniabu/elements.py
+++ b/iniabu/elements.py
@@ -35,8 +35,8 @@ class Elements(object):
 
         :param parent: Parent class.
         :type parent: class:`iniabu.IniAbu`
-        :param eles: Element dictionary.
-        :type eles: dict
+        :param eles: Elements to process.
+        :type eles: list(str)
         :param unit: Units used for return.
         :type unit: str
         :param *args: Variable length argument list.

--- a/iniabu/isotopes.py
+++ b/iniabu/isotopes.py
@@ -111,3 +111,12 @@ class Isotopes(object):
             ret_arr.append(data.isotopes_mass[iso])
         ret_arr = np.array(ret_arr)
         return return_list_simplifier(ret_arr)
+
+    @property
+    def name(self):
+        """Get the name of an isotope.
+
+        :return: Name of the set isotope(s).
+        :rtype: str, list(str)
+        """
+        return return_list_simplifier(self._isos)

--- a/iniabu/isotopes.py
+++ b/iniabu/isotopes.py
@@ -3,11 +3,12 @@
 This class manages the isotopes. It must be called from :class:`iniabu.IniAbu`.
 """
 
+import itertools
 
 import numpy as np
 
 from . import data
-from .utilities import return_list_simplifier
+from .utilities import get_all_isos, return_list_simplifier
 
 
 class Isotopes(object):
@@ -33,8 +34,8 @@ class Isotopes(object):
 
         :param parent: Parent class.
         :type parent: class:`iniabu.IniAbu`
-        :param isos: Isotope dictionary.
-        :type isos: dict
+        :param isos: Isotopes to process.
+        :type isos: list(str)
         :param unit: Units used for return.
         :type unit: str
         :param *args: Variable length argument list.
@@ -47,6 +48,15 @@ class Isotopes(object):
         # check for correct parent
         if parent.__class__.__name__ != "IniAbu":
             raise TypeError("Isotopes class must be initialized from IniAbu.")
+
+        # create isotopes with elements and isotopes available
+        tmp_isos = []
+        for entry in isos:
+            if entry in parent.ele_dict.keys():
+                tmp_isos.append(get_all_isos(parent, entry))
+            else:
+                tmp_isos.append([entry])  # for flattening list with itertools (std lib)
+        isos = list(itertools.chain(*tmp_isos))
 
         # set the variables
         self._isos = isos

--- a/iniabu/main.py
+++ b/iniabu/main.py
@@ -10,7 +10,12 @@ from . import data
 from . import utilities
 from .elements import Elements
 from .isotopes import Isotopes
-from .utilities import linear_units, ProxyList, return_as_ndarray, return_string_as_list
+from .utilities import (
+    linear_units,
+    ProxyList,
+    return_as_ndarray,
+    return_string_as_list,
+)
 
 
 class IniAbu(object):
@@ -111,7 +116,8 @@ class IniAbu(object):
             >>> ini.iso[["H-2", "He-3"]].abu_rel
             array([1.94e-05, 1.66e-04])
         """
-        return ProxyList(self, Isotopes, self._iso_dict.keys(), unit=self._unit)
+        valid_keys = list(self.iso_dict.keys()) + list(self.ele_dict.keys())
+        return ProxyList(self, Isotopes, valid_keys, unit=self._unit)
 
     # PROPERTIES #
 
@@ -578,10 +584,6 @@ class IniAbu(object):
             array([     0.        ,      0.        ,  75068.93030287,  77568.12815864,
                    189333.87185102])
         """
-        # if nominator is an element, get all isos
-        if nominator in self.ele_dict.keys():
-            nominator = self._get_all_isos(nominator)
-
         # values to numpy arrays
         sample_values = np.array(sample_values)
         sample_norm_values = np.array(sample_norm_values)
@@ -803,10 +805,6 @@ class IniAbu(object):
                     "is not allowed."
                 )
 
-        # check if elements are in nominator / denominator
-        if isinstance(nominator, str) and nominator in self._ele_dict.keys():
-            nominator = self._get_all_isos(nominator)
-
         if isinstance(denominator, str) and denominator in self._ele_dict.keys():
             denominator = self._get_major_iso(denominator)
 
@@ -834,19 +832,6 @@ class IniAbu(object):
         return ratio
 
     # PRIVATE METHODS #
-
-    def _get_all_isos(self, element):
-        """Get all isotopes for a given element.
-
-        :param element: Element.
-        :type element: str
-
-        :return: List of isotopes.
-        :rtype: list
-        """
-        isotopes = self.ele[element].iso_a
-        ret_val = ["{}-{}".format(element, isotope) for isotope in isotopes]
-        return ret_val
 
     def _get_major_iso(self, element):
         """Get the most abundant isotope for a given element.

--- a/iniabu/utilities.py
+++ b/iniabu/utilities.py
@@ -10,7 +10,7 @@ from . import data
 # CLASSES #
 
 
-class ProxyList(object):
+class ProxyList:
     """Proxy for accessing elements and isotopes as lists.
 
     This class is inspired by a class with the same name from the project
@@ -70,6 +70,22 @@ class ProxyList(object):
 
 
 # FUNCTIONS #
+
+
+def get_all_isos(ini, ele):
+    """Get all isotopes of a given element.
+
+    :param ini: Initialized iniabu instance
+    :type ini: IniAbu
+    :param ele: Element name
+    :type ele: str
+
+    :return: All isotopes of the element as a list.
+    :rtype: list(str)
+    """
+    isotopes = ini.ele[ele].iso_a
+    ret_val = ["{}-{}".format(ele, isotope) for isotope in isotopes]
+    return ret_val
 
 
 @contextmanager

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -186,3 +186,21 @@ def test_mass(ini_default, ele1, ele2):
     masses_expected = np.array([mass_expected1, mass_expected2])
     masses_gotten = ini_default.ele[[ele1, ele2]].mass
     np.testing.assert_equal(masses_gotten, masses_expected)
+
+
+@given(ele=st.sampled_from(list(iniabu.data.lodders09_elements.keys())))
+def test_name_single(ini_default, ele):
+    """Return the name of a given element."""
+    ele_name = ini_default.ele[ele].name
+    assert ele_name == ele
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
+def test_name_multi(ini_default, ele1, ele2):
+    """Return the names of multiple elements."""
+    names_expected = [ele1, ele2]
+    names_received = ini_default.ele[[ele1, ele2]].name
+    assert names_received == names_expected

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -6,6 +6,7 @@ import pytest
 
 import iniabu.data
 import iniabu.isotopes
+import iniabu.utilities
 
 
 def test_isotopes_require_parent_class():
@@ -21,7 +22,7 @@ def test_isotopes_wrong_unit():
     parent = iniabu.IniAbu()  # fake a correct parent
     unit = "random_unit"
     with pytest.raises(NotImplementedError) as err_info:
-        iniabu.isotopes.Isotopes(parent, "Si-28", unit=unit)
+        iniabu.isotopes.Isotopes(parent, ["Si-28"], unit=unit)
     err_msg = err_info.value.args[0]
     assert err_msg == f"The chosen unit {unit} is currently not implemented."
 
@@ -143,3 +144,32 @@ def test_name_multi(ini_default, iso1, iso2):
     names_expected = [iso1, iso2]
     names_received = ini_default.iso[[iso1, iso2]].name
     assert names_received == names_expected
+
+
+@given(ele=st.sampled_from(list(iniabu.data.lodders09_elements.keys())))
+def test_name_all_ele(ini_default, ele):
+    """Return the names of all isotopes if an element is passed on."""
+    isos = iniabu.utilities.get_all_isos(ini_default, ele)
+    assert ini_default.iso[ele].name == iniabu.utilities.return_list_simplifier(isos)
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
+def test_name_all_ele_multi(ini_default, ele1, ele2):
+    """Return the names of all isotopes if elements are passed on."""
+    isos = iniabu.utilities.get_all_isos(
+        ini_default, ele1
+    ) + iniabu.utilities.get_all_isos(ini_default, ele2)
+    assert ini_default.iso[[ele1, ele2]].name == isos
+
+
+@given(
+    iso=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+    ele=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
+def test_name_all_iso_and_ele(ini_default, iso, ele):
+    """Return the names of all isotopes for isotopes and element mixed."""
+    isos = [iso] + iniabu.utilities.get_all_isos(ini_default, ele)
+    assert ini_default.iso[[iso, ele]].name == isos

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -125,3 +125,21 @@ def test_mass(ini_default, iso1, iso2):
     )
     masses_gotten = ini_default.iso[[iso1, iso2]].mass
     np.testing.assert_equal(masses_gotten, masses_expected)
+
+
+@given(iso=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())))
+def test_name_single(ini_default, iso):
+    """Return the name of a given isotope."""
+    iso_name = ini_default.iso[iso].name
+    assert iso_name == iso
+
+
+@given(
+    iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+    iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+)
+def test_name_multi(ini_default, iso1, iso2):
+    """Return the names of multiple isotopes."""
+    names_expected = [iso1, iso2]
+    names_received = ini_default.iso[[iso1, iso2]].name
+    assert names_received == names_expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -126,15 +126,6 @@ def test_unit_invalid(ini_default):
 
 
 @given(ele=st.sampled_from(list(data.lodders09_elements.keys())))
-def test_get_all_isos(ini_default, ele):
-    """Ensure appropriate isotope list is returned for a given element."""
-    iso_list = []
-    for iso in ini_default.ele_dict[ele][1]:
-        iso_list.append(f"{ele}-{iso}")
-    assert ini_default._get_all_isos(ele) == iso_list
-
-
-@given(ele=st.sampled_from(list(data.lodders09_elements.keys())))
 def test_get_major_iso(ini_default, ele):
     """Ensure that the correct major isotope is returned."""
     index = np.array(ini_default.ele_dict[ele][2]).argmax()

--- a/tests/test_main_int_norm.py
+++ b/tests/test_main_int_norm.py
@@ -4,6 +4,8 @@ from hypothesis import given, strategies as st
 import numpy as np
 import pytest
 
+from iniabu.utilities import get_all_isos
+
 
 # INTERNAL NORMALIZATION #
 
@@ -144,7 +146,7 @@ def test_iso_int_norm_exp_single_delta(ini_default, delta_fct):
 def test_iso_int_norm_exp_multi_isos(ini_default, smp_values):
     """Internal normalization using exponential law for multiple isotopes."""
     nominator_ele = "Ni"
-    nominator_isos = ini_default._get_all_isos(nominator_ele)
+    nominator_isos = get_all_isos(ini_default, nominator_ele)
     norm_isos_ind = (0, 3)
     norm_isos = (nominator_isos[norm_isos_ind[0]], nominator_isos[norm_isos_ind[1]])
     smp_values = np.array(smp_values)
@@ -185,7 +187,7 @@ def test_iso_int_norm_exp_multi_isos(ini_default, smp_values):
 def test_iso_int_norm_lin_multi(ini_default, smp_values):
     """Internal normalization using linear law for multiple isotopes."""
     nominator_ele = "Ni"
-    nominator_isos = ini_default._get_all_isos(nominator_ele)
+    nominator_isos = get_all_isos(ini_default, nominator_ele)
     norm_isos_ind = (0, 3)
     norm_isos = (nominator_isos[norm_isos_ind[0]], nominator_isos[norm_isos_ind[1]])
     smp_values = np.array(smp_values)

--- a/tests/test_main_ratios.py
+++ b/tests/test_main_ratios.py
@@ -6,6 +6,7 @@ import pytest
 
 import iniabu
 import iniabu.data as data
+from iniabu.utilities import get_all_isos
 
 
 # RATIOS ELEMENT #
@@ -199,7 +200,7 @@ def test_iso_ratio_isos_isos_length_mismatch(ini_default):
 )
 def test_iso_ratio_ele_iso(ini_default, ele1, iso2):
     """Calculae isotope ratios for all isotopes of an element versus one isotope."""
-    all_isos = ini_default._get_all_isos(ele1)
+    all_isos = get_all_isos(ini_default, ele1)
     val_exp = np.empty(len(all_isos))
     for it, iso in enumerate(all_isos):
         val_exp[it] = ini_default.iso_dict[iso][1] / ini_default.iso_dict[iso2][1]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -11,6 +11,7 @@ import iniabu.data
 import iniabu.elements
 import iniabu.utilities
 from iniabu.utilities import (
+    get_all_isos,
     linear_units,
     make_iso_dict,
     make_log_abu_dict,
@@ -62,6 +63,15 @@ def test_proxy_list_length(ini_default):
 
 
 # FUNCTIONS #
+
+
+@given(ele=st.sampled_from(list(iniabu.data.lodders09_elements.keys())))
+def test_get_all_isos(ini_default, ele):
+    """Ensure appropriate isotope list is returned for a given element."""
+    iso_list = []
+    for iso in ini_default.ele_dict[ele][1]:
+        iso_list.append(f"{ele}-{iso}")
+    assert get_all_isos(ini_default, ele) == iso_list
 
 
 def test_linear_units_switch(ini_mf):


### PR DESCRIPTION
Added functionality to query the name of an isotope or element instance. This will return what the user as selected. Kind of useless on its own, however, combined with the next function, great.

Added functionality to query all isotopes of a given element. Example:

```python
>>> from iniabu import ini
>>> iso = ini.iso["Ne"]
>>> iso.name
["Ne-20", "Ne-21", "Ne-22"]
```