### PR TITLE
Release v1.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.11.0
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.11.1
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.1
+current_version = 1.0.0
 commit = True
 tag = False
 

--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,9 @@ As one might guess,
 Functions that are useful for everyday's life as an
 astrophysicist, cosmo-, or geochemist,
 are here made available in an easy to use interface.
-You can find more information on the scientific background
-`here <https://iniabu.readthedocs.io/en/latest/background.html>`_.
+More information can also be found in the
+`scientific background section <https://iniabu.readthedocs.io/en/latest/background.html>`_
+in the documentation.
 Aside from querying the databases,
 the ``iniabu`` tool allows you directly
 to calculate isotope ratios,

--- a/README.rst
+++ b/README.rst
@@ -68,23 +68,24 @@ We welcome all contributions,
 from simple typo fixes in the documentation,
 to feature contributions!
 
-.. note:: Currently the package is still in testing
-  and has not been released on PyPi as v1.0.0.
-  You can always check the badge above to see
-  which version is currently available on PyPi.
-  Please follow the instructions on the
-  `Installation and Usage <https://iniabu.readthedocs.io/en/latest/intro.html>`_
-  page to see how to install the package from GitHub.
-
 Installation
 ------------
 
-This package is not yet available on PyPi.
-You can install it however directly from GitHub:
+The stable version of this package
+is available and PyPi
+and can be installed as:
 
 .. code-block:: console
 
-    $ pip install git+https://github.com/galactic-forensics/iniabu.git
+  $ pip install iniabu
+
+Alternatively,
+you can install the latest version
+directly from GitHub:
+
+.. code-block:: console
+
+  $ pip install git+https://github.com/galactic-forensics/iniabu.git
 
 
 Issues and feature requests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ sys.path.append("../")
 project = "iniabu"
 author = "Reto Trappitsch"
 copyright = "2020, {}".format(author)
-version = "0.11.1"
+version = "1.0.0"
 release = version
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ sys.path.append("../")
 project = "iniabu"
 author = "Reto Trappitsch"
 copyright = "2020, {}".format(author)
-version = "0.11.0"
+version = "0.11.1"
 release = version
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ sys.path.append("../")
 project = "iniabu"
 author = "Reto Trappitsch"
 copyright = "2020, {}".format(author)
-version = "0.10.0"
+version = "0.11.0"
 release = version
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,8 +37,8 @@ As one might guess,
 Functions that are useful for everyday's life as an
 astrophysicist, cosmo-, or geochemist,
 are here made available in an easy to use interface.
-You can find more information on the scientific background
-:doc:`here <background>`.
+More information can also be found in the
+:doc:`scientific background section <background>`.
 Aside from querying the databases,
 the ``iniabu`` tool allows you directly
 to calculate isotope ratios,
@@ -65,14 +65,6 @@ hopefully detailed,
 We welcome all contributions,
 from simple typo fixes in the documentation,
 to feature contributions!
-
-.. note:: Currently the package is still in testing
-  and has not been released on PyPi as v1.0.0.
-  You can always check the badge above to see
-  which version is currently available on PyPi.
-  Please follow the instructions on the
-  :doc:`Installation and Usage <intro>`
-  page to see how to install the package from GitHub.
 
 
 Issues and feature requests

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -21,19 +21,15 @@ and the latest one should be working great.
 Installation
 ------------
 
-.. warning:: Currently,
-    this package can only be installed from its GitHub repository.
-    Installation directly from PyPi
-    will result in the old version (v0.3.1) being installed.
-
-To install the iniabu project,
+To install the latest stable version of ``iniabu``,
 run this command in your terminal:
 
 .. code-block:: console
 
    $ pip install iniabu
 
-Alternatively you can install the ``iniabu`` project directly from GitHub.
+Alternatively you can install ``iniabu`` directly from GitHub.
+This will install the latest version.
 To do so, type in your terminal:
 
 .. code-block:: console

--- a/iniabu/__init__.py
+++ b/iniabu/__init__.py
@@ -8,7 +8,7 @@ inimf = IniAbu(unit="mass_fraction")
 inilog = IniAbu(unit="num_log")
 
 # Package information
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 __title__ = "iniabu"
 __description__ = (

--- a/iniabu/__init__.py
+++ b/iniabu/__init__.py
@@ -8,7 +8,7 @@ inimf = IniAbu(unit="mass_fraction")
 inilog = IniAbu(unit="num_log")
 
 # Package information
-__version__ = "0.11.1"
+__version__ = "1.0.0"
 
 __title__ = "iniabu"
 __description__ = (

--- a/iniabu/__init__.py
+++ b/iniabu/__init__.py
@@ -8,7 +8,7 @@ inimf = IniAbu(unit="mass_fraction")
 inilog = IniAbu(unit="num_log")
 
 # Package information
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 __title__ = "iniabu"
 __description__ = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "flit_core.buildapi"
 [tool.flit.metadata]
 module = "iniabu"
 author = "Reto Trappitsch"
-author-email = "trappitsch@users.noreply.github.com"
+author-email = "reto@galactic-forensics.space"
 home-page = "https://github.com/galactic-forensics/iniabu"
 requires = ["numpy"]
 requires-python=">=3.6"
 description-file="README.rst"
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
@@ -32,16 +32,16 @@ dev = [
     "flake8-black",
     "flake8-bugbear",
     "flake8-docstrings",
-    "flake8-import-order"
+    "flake8-import-order",
 ]
 doc = [
-    "pytest",
     "sphinx",
     "sphinx_rtd_theme"
 ]
 test = [
     "pytest",
     "pytest-cov",
+    "pytest-mock",
     "pytest-sugar"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module = "iniabu"
 author = "Reto Trappitsch"
 author-email = "reto@galactic-forensics.space"
 home-page = "https://github.com/galactic-forensics/iniabu"
-requires = ["numpy>=1.19.4"]
+requires = ["numpy"]
 requires-python=">=3.6"
 description-file="README.rst"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ module = "iniabu"
 author = "Reto Trappitsch"
 author-email = "reto@galactic-forensics.space"
 home-page = "https://github.com/galactic-forensics/iniabu"
-requires = ["numpy"]
+requires = ["numpy>=1.19.4"]
 requires-python=">=3.6"
 description-file="README.rst"
 classifiers = [
@@ -26,7 +26,7 @@ classifiers = [
 
 [tool.flit.metadata.requires-extra]
 dev = [
-    "darglint<1.5.0",
+    "darglint>=1.5.1",
     "flake8",
     "flake8-bandit",
     "flake8-black",


### PR DESCRIPTION
First release of the new `iniabu` package.

*Note*: The package on `testpypi` does not work because it cannot install `numpy`. It tries to install `numpy` from `testpypi`, which is a very old version only. If `numpy` is installed manually, everything works as wanted.