### PR TITLE
Z, A quere & Default DB note

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -114,6 +114,12 @@ The respective imports for these are:
   >>> from iniabu import inimf  # mass fraction
 
 
+.. note:: While the current default database is Lodders et al. (2009)
+  we will not consider loading a different default database
+  a breaking change.
+  If you want to always load Lodders et al. (2009),
+  use the specific import below.
+
 In case multiple databases
 are required at the same time,
 e.g., :code:`db1` using Lodders et al. (2009)
@@ -279,6 +285,8 @@ from the element:
   the relative abundances will also be given
   as mass fractions!
 - The solar abundances of its (stable) isotopes using ``iso_abu_solar``
+- The number of protons of an element
+  can be queried with ``z``.
 
 For example,
 to query the solar abundance of iron
@@ -315,6 +323,9 @@ as following:
 The following properties can then
 be queried from this isotope:
 
+- The number of nucleons / mass number
+  of an isotope
+  can be queried with ``a``.
 - The name of the isotope(s) requested
   can be queried with ``name``.
 - The mass of a specific isotope using ``mass``.
@@ -327,6 +338,8 @@ be queried from this isotope:
   If you are using "mass_fractions" as units,
   the relative abundances will also be given
   as mass fractions!
+- The number of protons of an isotope
+  can be queried with ``z``.
 
 For example:
 To query the solar and the relative abundances

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -40,15 +40,19 @@ To do so, type in your terminal:
 Available databases
 -------------------
 Several databases are available to work with.
-The default database is called "lodders09"
+The current default database is called "lodders09"
 and is based on
 `Lodders et al. (2009) <https://doi.org/10.1007/978-3-540-88055-4_34>`_.
+This might be updated in the future
+without considering it
+a breaking change.
+Old databases will always stay available.
 Further databases,
 listed by the string used to call them,
 are as following:
 
 - "asplund09": `Asplund et al. (2009) <https://doi.org/10.1146/annurev.astro.46.060407.145222>`_
-- "lodders09" (default): `Lodders et al. (2009) <https://doi.org/10.1007/978-3-540-88055-4_34>`_
+- "lodders09" (current default): `Lodders et al. (2009) <https://doi.org/10.1007/978-3-540-88055-4_34>`_
 - "nist": `NIST database <https://www.nist.gov/pml/atomic-weights-and-isotopic-compositions-relative-atomic-masses>`_
 
 The solar abundances of all databases

--- a/iniabu/elements.py
+++ b/iniabu/elements.py
@@ -161,3 +161,15 @@ class Elements(object):
         :rtype: str, list(str)
         """
         return return_list_simplifier(self._eles)
+
+    @property
+    def z(self):
+        """Get the number of protons for the element.
+
+        :return: Number of protons for the set element(s).
+        :rtype: int, ndarray<int>
+        """
+        ret_arr = np.zeros(len(self._eles), dtype=int)
+        for it, ele in enumerate(self._eles):
+            ret_arr[it] = data.elements_z[ele]
+        return return_list_simplifier(ret_arr)

--- a/iniabu/isotopes.py
+++ b/iniabu/isotopes.py
@@ -74,6 +74,22 @@ class Isotopes(object):
     # PROPERTIES #
 
     @property
+    def a(self):
+        """Get total number of nucleons for given isotope.
+
+        Returns the total number of nucleons for the given isotope. Sure, this is
+        already passed as an argument in the isotope name, however, might be useful
+        for plotting to have a return for it.
+
+        :return: Mass number of isotope
+        :rtype: int, ndarray<int>
+        """
+        ret_arr = np.zeros(len(self._isos), dtype=int)
+        for it, iso in enumerate(self._isos):
+            ret_arr[it] = iso.split("-")[1]
+        return return_list_simplifier(ret_arr)
+
+    @property
     def abu_rel(self):
         """Get relative abundance of isotope(s).
 
@@ -130,3 +146,30 @@ class Isotopes(object):
         :rtype: str, list(str)
         """
         return return_list_simplifier(self._isos)
+
+    @property
+    def z(self):
+        """Get the number of protons for the element.
+
+        :return: Number of protons for the set element(s).
+        :rtype: int, ndarray<int>
+        """
+        eles = self._element
+        ret_arr = np.zeros(len(eles), int)
+        for it, ele in enumerate(eles):
+            ret_arr[it] = data.elements_z[ele]
+        return return_list_simplifier(ret_arr)
+
+    # private properties and functions
+
+    @property
+    def _element(self):
+        """Return the elements associated with the isotope.
+
+        :return: Name of element(s).
+        :rtype: str, list(str)
+        """
+        ret_arr = []
+        for iso in self._isos:
+            ret_arr.append(iso.split("-")[0])
+        return ret_arr

--- a/iniabu/isotopes.py
+++ b/iniabu/isotopes.py
@@ -155,7 +155,7 @@ class Isotopes(object):
         :rtype: int, ndarray<int>
         """
         eles = self._element
-        ret_arr = np.zeros(len(eles), int)
+        ret_arr = np.zeros(len(eles), dtype=int)
         for it, ele in enumerate(eles):
             ret_arr[it] = data.elements_z[ele]
         return return_list_simplifier(ret_arr)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -212,10 +212,12 @@ def test_name_multi(ini_default, ele1, ele2):
 )
 def test_z(ini_default, ele1, ele2):
     """Get the number of protons for element."""
-    # single
     z_ele = iniabu.data.elements_z[ele1]
-    assert ini_default.ele[ele1].z == z_ele
+    ret_val = ini_default.ele[ele1].z
+    assert isinstance(ret_val, np.int64)
+    assert ret_val == z_ele
 
-    # list
     z_eles = np.array([z_ele, iniabu.data.elements_z[ele2]])
-    np.testing.assert_equal(ini_default.ele[[ele1, ele2]].z, z_eles)
+    ret_val = ini_default.ele[[ele1, ele2]].z
+    assert ret_val.dtype == np.int64
+    np.testing.assert_equal(ret_val, z_eles)

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -204,3 +204,18 @@ def test_name_multi(ini_default, ele1, ele2):
     names_expected = [ele1, ele2]
     names_received = ini_default.ele[[ele1, ele2]].name
     assert names_received == names_expected
+
+
+@given(
+    ele1=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+    ele2=st.sampled_from(list(iniabu.data.lodders09_elements.keys())),
+)
+def test_z(ini_default, ele1, ele2):
+    """Get the number of protons for element."""
+    # single
+    z_ele = iniabu.data.elements_z[ele1]
+    assert ini_default.ele[ele1].z == z_ele
+
+    # list
+    z_eles = np.array([z_ele, iniabu.data.elements_z[ele2]])
+    np.testing.assert_equal(ini_default.ele[[ele1, ele2]].z, z_eles)

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -41,6 +41,19 @@ def test_isotopes_isos_list(ini_default, iso1, iso2):
     iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
     iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
 )
+def test_a(ini_default, iso1, iso2):
+    """Return mass number of isotope (what is actually put in already)."""
+    assert ini_default.iso[iso1].a == int(iso1.split("-")[1])
+    np.testing.assert_equal(
+        ini_default.iso[[iso1, iso2]].a,
+        np.array([int(iso1.split("-")[1]), int(iso2.split("-")[1])]),
+    )
+
+
+@given(
+    iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+    iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+)
 def test_abu_rel(ini_default, iso1, iso2):
     """Test isotope relative abundance returner."""
     assert ini_default.iso[iso1].abu_rel == iniabu.data.lodders09_isotopes[iso1][0]
@@ -173,3 +186,24 @@ def test_name_all_iso_and_ele(ini_default, iso, ele):
     """Return the names of all isotopes for isotopes and element mixed."""
     isos = [iso] + iniabu.utilities.get_all_isos(ini_default, ele)
     assert ini_default.iso[[iso, ele]].name == isos
+
+
+@given(
+    iso1=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+    iso2=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())),
+)
+def test_z(ini_default, iso1, iso2):
+    """Get the number of protons for element."""
+    # single
+    z_ele = iniabu.data.elements_z[iso1.split("-")[0]]
+    assert ini_default.iso[iso1].z == z_ele
+
+    # list
+    z_eles = np.array([z_ele, iniabu.data.elements_z[iso2.split("-")[0]]])
+    np.testing.assert_equal(ini_default.iso[[iso1, iso2]].z, z_eles)
+
+
+def test_element(ini_default):
+    """Return the elements of selected isotopes as strings."""
+    assert ini_default.iso["H-2"]._element == ["H"]  # must be list
+    assert ini_default.iso[["U-235", "Ne-21", "Ne-22"]]._element == ["U", "Ne", "Ne"]

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -43,9 +43,14 @@ def test_isotopes_isos_list(ini_default, iso1, iso2):
 )
 def test_a(ini_default, iso1, iso2):
     """Return mass number of isotope (what is actually put in already)."""
-    assert ini_default.iso[iso1].a == int(iso1.split("-")[1])
+    ret_val = ini_default.iso[iso1].a
+    assert isinstance(ret_val, np.int64)
+    assert ret_val == int(iso1.split("-")[1])
+
+    ret_val = ini_default.iso[[iso1, iso2]].a
+    assert ret_val.dtype == np.int64
     np.testing.assert_equal(
-        ini_default.iso[[iso1, iso2]].a,
+        ret_val,
         np.array([int(iso1.split("-")[1]), int(iso2.split("-")[1])]),
     )
 
@@ -194,13 +199,16 @@ def test_name_all_iso_and_ele(ini_default, iso, ele):
 )
 def test_z(ini_default, iso1, iso2):
     """Get the number of protons for element."""
-    # single
     z_ele = iniabu.data.elements_z[iso1.split("-")[0]]
-    assert ini_default.iso[iso1].z == z_ele
+    ret_val = ini_default.iso[iso1].z
+    assert isinstance(ret_val, np.int64)
+    assert ret_val == z_ele
 
     # list
     z_eles = np.array([z_ele, iniabu.data.elements_z[iso2.split("-")[0]]])
-    np.testing.assert_equal(ini_default.iso[[iso1, iso2]].z, z_eles)
+    ret_val = ini_default.iso[[iso1, iso2]].z
+    assert ret_val.dtype == np.int64
+    np.testing.assert_equal(ret_val, z_eles)
 
 
 def test_element(ini_default):


### PR DESCRIPTION
- Add functionality to query proton number (Z) for elements and isotopes, query total number of nucleons (A) for isotopes.
- Added note that Lodders+ (2009) is currently the default database, however, won't be in the future considered a breaking change if updated to a newer and better version.

Closes #32 