### PR TITLE
Update NIST to allow return of isotope ratios

### DIFF
--- a/iniabu/main.py
+++ b/iniabu/main.py
@@ -27,7 +27,16 @@ class IniAbu(object):
     - ``lodders09``: Lodders et al. (2009), doi: 10.1007/978-3-540-88055-4_34
     - ``nist``: Current (as of 2020) NIST isotopic abundances.
 
-    Todo Example
+    For detailed examples, see: https://iniabu.readthedocs.io/
+
+    Example:
+        >>> from iniabu import ini
+        >>> ini.iso["Ne"].name
+        ['Ne-20', 'Ne-21', 'Ne-22']
+        >>> ini.iso["Ne"].abu_solar
+        array([3060000.,    7330.,  225000.])
+        >>> ini.iso_delta("Si-30", "Si-28", 0.02)
+        -403.23624595469255
     """
 
     def __init__(self, database="lodders09", unit="num_lin"):

--- a/iniabu/main.py
+++ b/iniabu/main.py
@@ -810,8 +810,12 @@ class IniAbu(object):
 
         # get the values back:
         with linear_units(self, mass_fraction=mass_fraction) as ini_tmp:
-            nominator_value = ini_tmp.iso[nominator].abu_solar
-            denominator_value = ini_tmp.iso[denominator].abu_solar
+            if self._database == "nist":
+                nominator_value = ini_tmp.iso[nominator].abu_rel
+                denominator_value = ini_tmp.iso[denominator].abu_rel
+            else:
+                nominator_value = ini_tmp.iso[nominator].abu_solar
+                denominator_value = ini_tmp.iso[denominator].abu_solar
 
         ratio = nominator_value / denominator_value
 
@@ -828,6 +832,12 @@ class IniAbu(object):
                 np.array(denominator_masses) / np.array(nominator_masses)
             )
             ratio /= corr_factor
+
+        # if nist database, we need to check for the same elements, otherwise nan
+        if self._database == "nist":
+            z_ratio = self.iso[nominator].z / self.iso[denominator].z  # ratio of Z
+            ratio = np.where(np.array(z_ratio) == 1, np.array(ratio), np.nan)
+            # ratio = utilities.return_list_simplifier(ratio)
 
         return ratio
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,6 +15,7 @@ python_main = "3.9"
 def black(session):
     """Autoformat all python files with black."""
     args = session.posargs or locations
+    session.install("--upgrade", "pip")
     session.install("black==20.8b1")
     session.run("black", *args)
 
@@ -29,6 +30,7 @@ def build(session):
 @nox.session(python=python_main)
 def docs(session):
     """Build the documentation."""
+    session.install("--upgrade", "pip")
     session.install("sphinx", "sphinx_rtd_theme", "-r", "requirements.txt", "pytest")
     session.chdir("docs")
     session.run(
@@ -40,6 +42,7 @@ def docs(session):
 def lint(session):
     """Lint project using ``flake8``."""
     args = session.posargs or locations
+    session.install("--upgrade", "pip")
     session.install("-r", "dev-requirements.txt")
     session.run("flake8", *args)
 
@@ -47,6 +50,7 @@ def lint(session):
 @nox.session(python=python_suite)
 def tests(session):
     """Test the project using ``pytest``."""
+    session.install("--upgrade", "pip")
     session.install("-r", "requirements.txt", "-r", "dev-requirements.txt")
     session.run("pytest")
 
@@ -54,6 +58,7 @@ def tests(session):
 @nox.session(python=python_main)
 def safety(session):
     """Safety check for all dependencies."""
+    session.install("--upgrade", "pip")
     session.install("safety", "-r", "requirements.txt", "-r", "dev-requirements.txt")
     session.run(
         "safety",
@@ -66,5 +71,6 @@ def safety(session):
 def xdoctest(session):
     """Test docstring examples with xdoctest."""
     args = session.posargs or ["all"]
+    session.install("--upgrade", "pip")
     session.install("xdoctest[all]", "-r", "requirements.txt")
     session.run("python", "-m", "xdoctest", package, *args)

--- a/tests/test_main_ratios.py
+++ b/tests/test_main_ratios.py
@@ -287,3 +287,36 @@ def test_iso_ratio_iso_ele(ini_default, iso, ele):
     iso_denominator = ini_default._get_major_iso(ele)
     val_exp = ini_default.iso_dict[iso][1] / ini_default.iso_dict[iso_denominator][1]
     assert ini_default.iso_ratio(iso, ele) == val_exp
+
+
+# TESTS FOR NIST RATIOS - USE RELATIVE IF THE SAME ELEMENT THROUGHOUT THE BOARD
+
+
+def test_nist_ratio_iso_iso(ini_nist):
+    """If NIST db, calculate isotope ratios (same element) from relative ratio."""
+    iso1 = "Ne-21"
+    iso2 = "Ne-22"
+    expected = ini_nist.iso_dict[iso1][0] / ini_nist.iso_dict[iso2][0]
+    assert ini_nist.iso_ratio(iso1, iso2) == expected
+
+
+def test_nist_ratio_iso_iso_unequal(ini_nist):
+    """Return nan if NIST db and isotope ratio of different elements requested."""
+    iso1 = "He-3"
+    iso2 = "Ne-21"
+    assert np.isnan(ini_nist.iso_ratio(iso1, iso2))
+
+
+def test_nist_ratio_isos_isos(ini_nist):
+    """Assortment of tests for NIST db isoratio return."""
+    nom = ["He-3", "Ne-21", "Ne-22", "Ar-36"]
+    denom = ["Ne-20", "Ne-20", "He-4", "Ar-38"]
+    expected = np.array(
+        [
+            np.nan,
+            ini_nist.iso_dict[nom[1]][0] / ini_nist.iso_dict[denom[1]][0],
+            np.nan,
+            ini_nist.iso_dict[nom[3]][0] / ini_nist.iso_dict[denom[3]][0],
+        ]
+    )
+    np.testing.assert_equal(ini_nist.iso_ratio(nom, denom), expected)


### PR DESCRIPTION
Change isotope ratio routine such that when NIST database is loaded, it automatically uses relative isotope ratios and checks if the same elements called. Otherwise return nan.