### PR TITLE
Bump version: 1.0.0 → 1.0.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = True
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 1.0.1
 commit = True
-tag = False
+tag = True
 
 [bumpversion:file:docs/conf.py]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ sys.path.append("../")
 project = "iniabu"
 author = "Reto Trappitsch"
 copyright = "2020, {}".format(author)
-version = "1.0.0"
+version = "1.0.1"
 release = version
 
 

--- a/iniabu/__init__.py
+++ b/iniabu/__init__.py
@@ -8,7 +8,7 @@ inimf = IniAbu(unit="mass_fraction")
 inilog = IniAbu(unit="num_log")
 
 # Package information
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 __title__ = "iniabu"
 __description__ = (


### PR DESCRIPTION
- NIST database can now return delta-values for same elements
  - See #33, #35 
- Added capability to retrieve A and Z (isos), Z for elements
  - See #34 