### PR TITLE
Add capability to call with various isotope names

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -269,6 +269,7 @@ can be loaded into a variable as following:
 
     >>> ele = ini.ele["Si"]
 
+Note that element names are not case sensitive.
 The following properties can now be queried
 from the element:
 
@@ -324,6 +325,10 @@ as following:
 
     >>> iso = ini.iso["Fe-54"]
 
+You can also use alternative spellings for the isotope name,
+e.g., ``"54Fe"`` or ``"Fe54"``.
+Furthermore,
+none of these spellings are case sensitive.
 The following properties can then
 be queried from this isotope:
 
@@ -332,6 +337,8 @@ be queried from this isotope:
   can be queried with ``a``.
 - The name of the isotope(s) requested
   can be queried with ``name``.
+  These names will always be in the standard format,
+  e.g., ``"Fe-54"``.
 - The mass of a specific isotope using ``mass``.
 - The solar abundance of the isotope itself using ``abu_solar``,
   normed as discussed above

--- a/iniabu/isotopes.py
+++ b/iniabu/isotopes.py
@@ -22,6 +22,9 @@ class Isotopes(object):
         >>> isotope.abu_rel
         0.9223
 
+    .. note:: You can also call isotopes using alternative spellings, e.g.,
+        "28Si" or "Si28".
+
     .. warning:: This class should NOT be manually created by the user. It is
         designed to be initialized by :class:`iniabu.IniAbu`
     """
@@ -141,6 +144,9 @@ class Isotopes(object):
     @property
     def name(self):
         """Get the name of an isotope.
+
+        If an alternative spelling was used to call the isotope, e.g., "Si28" or "28Si",
+        the name will still be returnd as "Si-28", which is the default for `iniabu`.
 
         :return: Name of the set isotope(s).
         :rtype: str, list(str)

--- a/iniabu/utilities.py
+++ b/iniabu/utilities.py
@@ -91,15 +91,18 @@ def get_all_isos(ini, ele):
 
 
 def item_formatter(iso: str) -> str:
-    """Transform iso either into correct format, e.g,. from `46Ti` to `Ti-46`.
+    """Transform `iso` into correct format, e.g,. from `46Ti` to `Ti-46`
+
+    Also appropriately capitalizes isotopes and elements.
 
     Supported formats:
     - `46Ti`
+    - `Ti46`
     - `Ti-46`
 
-    :param iso: Isotope as string
+    :param iso: Isotope as string or element name.
 
-    :return: iso, but in transformed notation
+    :return: iso, but in transformed notation and capitalized
     """
     if "-" in iso:
         iso_split = iso.split("-")

--- a/iniabu/utilities.py
+++ b/iniabu/utilities.py
@@ -91,7 +91,7 @@ def get_all_isos(ini, ele):
 
 
 def item_formatter(iso: str) -> str:
-    """Transform `iso` into correct format, e.g,. from `46Ti` to `Ti-46`
+    """Transform `iso` into correct format, e.g,. from `46Ti` to `Ti-46`.
 
     Also appropriately capitalizes isotopes and elements.
 

--- a/iniabu/utilities.py
+++ b/iniabu/utilities.py
@@ -50,6 +50,8 @@ class ProxyList:
 
     def __getitem__(self, idx):
         """Get an item from the proxy list."""
+        # call iso transformer
+        idx = iso_transform(idx)
         # turn idx into a list
         if isinstance(idx, tuple):
             idx = list(idx)
@@ -86,6 +88,37 @@ def get_all_isos(ini, ele):
     isotopes = ini.ele[ele].iso_a
     ret_val = ["{}-{}".format(ele, isotope) for isotope in isotopes]
     return ret_val
+
+
+def iso_transform(iso: str) -> str:
+    """Transform iso either into correct format, e.g,. from `46Ti` to `Ti-46`.
+
+    Supported formats:
+    - `46Ti`
+    - `Ti-46`
+
+    :param iso: Isotope as string
+
+    :return: iso, but in transformed notation
+    """
+    if "-" in iso:
+        return iso
+    elif iso[0].isnumeric():  # mass number comes first
+        index_to = None
+        for it, char in enumerate(iso):
+            if not char.isnumeric():
+                index_to = it
+                break
+        return f"{iso[index_to:]}-{iso[:index_to]}"
+    elif iso[-1].isnumeric():  # mass number comes last
+        index_to = None
+        for it, char in enumerate(iso):
+            if char.isnumeric():
+                index_to = it
+                break
+        return f"{iso[:index_to]}-{iso[index_to:]}"
+    else:
+        return iso  # no rule applied, return input (important for elements!)
 
 
 @contextmanager

--- a/iniabu/utilities.py
+++ b/iniabu/utilities.py
@@ -50,19 +50,19 @@ class ProxyList:
 
     def __getitem__(self, idx):
         """Get an item from the proxy list."""
-        # call iso transformer
-        idx = iso_transform(idx)
         # turn idx into a list
         if isinstance(idx, tuple):
             idx = list(idx)
         # turn into list if required
         idx = return_string_as_list(idx)
 
-        for it in idx:
-            if it not in self._valid_set:
+        for it, entry in enumerate(idx):
+            entry = item_formatter(entry)
+            idx[it] = entry
+            if entry not in self._valid_set:
                 raise IndexError(
                     "Item {} out of range. Must be "
-                    "in {}.".format(it, self._valid_set)
+                    "in {}.".format(entry, self._valid_set)
                 )
         return self._proxy_cls(self._parent, idx, *self.args, **self.kwargs)
 
@@ -90,7 +90,7 @@ def get_all_isos(ini, ele):
     return ret_val
 
 
-def iso_transform(iso: str) -> str:
+def item_formatter(iso: str) -> str:
     """Transform iso either into correct format, e.g,. from `46Ti` to `Ti-46`.
 
     Supported formats:
@@ -102,23 +102,24 @@ def iso_transform(iso: str) -> str:
     :return: iso, but in transformed notation
     """
     if "-" in iso:
-        return iso
+        iso_split = iso.split("-")
+        return f"{iso_split[0].capitalize()}-{iso_split[1]}"
     elif iso[0].isnumeric():  # mass number comes first
         index_to = None
         for it, char in enumerate(iso):
             if not char.isnumeric():
                 index_to = it
                 break
-        return f"{iso[index_to:]}-{iso[:index_to]}"
+        return f"{iso[index_to:].capitalize()}-{iso[:index_to]}"
     elif iso[-1].isnumeric():  # mass number comes last
         index_to = None
         for it, char in enumerate(iso):
             if char.isnumeric():
                 index_to = it
                 break
-        return f"{iso[:index_to]}-{iso[index_to:]}"
+        return f"{iso[:index_to].capitalize()}-{iso[index_to:]}"
     else:
-        return iso  # no rule applied, return input (important for elements!)
+        return iso.capitalize()  # no rule applied, return input (e.g., elements)
 
 
 @contextmanager

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -221,3 +221,10 @@ def test_z(ini_default, ele1, ele2):
     ret_val = ini_default.ele[[ele1, ele2]].z
     assert ret_val.dtype == np.int64
     np.testing.assert_equal(ret_val, z_eles)
+
+
+def test_element_naming_case_sensitivity(ini_default):
+    """Call element with any capitalization."""
+    assert ini_default.ele["ti"].name == "Ti"
+    assert ini_default.ele["tI"].name == "Ti"
+    assert ini_default.ele["TI"].name == "Ti"

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -219,7 +219,7 @@ def test_element(ini_default):
 
 @given(iso=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())))
 def test_isotope_naming_schemes(ini_default, iso):
-    """Call isotopes with various naming schemes; ENH 2021-08-07."""
+    """Call isotopes with various naming schemes."""
     # Naming mass number first, e.g., 235U
     iso_split = iso.split("-")  # 0 is name, 1 is mass number
     iso_aa_first = f"{iso_split[1]}{iso_split[0]}"

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -215,3 +215,12 @@ def test_element(ini_default):
     """Return the elements of selected isotopes as strings."""
     assert ini_default.iso["H-2"]._element == ["H"]  # must be list
     assert ini_default.iso[["U-235", "Ne-21", "Ne-22"]]._element == ["U", "Ne", "Ne"]
+
+
+@given(iso=st.sampled_from(list(iniabu.data.lodders09_isotopes.keys())))
+def test_isotope_naming_schemes(ini_default, iso):
+    """Call isotopes with various naming schemes; ENH 2021-08-07."""
+    # Naming mass number first, e.g., 235U
+    iso_split = iso.split("-")  # 0 is name, 1 is mass number
+    iso_aa_first = f"{iso_split[1]}{iso_split[0]}"
+    assert ini_default.iso[iso_aa_first].name == iso

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -224,3 +224,28 @@ def test_isotope_naming_schemes(ini_default, iso):
     iso_split = iso.split("-")  # 0 is name, 1 is mass number
     iso_aa_first = f"{iso_split[1]}{iso_split[0]}"
     assert ini_default.iso[iso_aa_first].name == iso
+
+
+def test_isotope_naming_schemes_list(ini_default):
+    """Call the isotope naming scheme on a list."""
+    isos_in = ["28Si", "29Si"]
+    isos_exp = ["Si-28", "Si-29"]
+    assert ini_default.iso[isos_in].name == isos_exp
+
+
+def test_isotopes_naming_schemes_mixed(ini_default):
+    """Input list with mixed naming schemes."""
+    isos_in = ["Si-28", "29Si", "Si30"]
+    isos_exp = ["Si-28", "Si-29", "Si-30"]
+    assert ini_default.iso[isos_in].name == isos_exp
+
+
+def test_isotope_naming_case_sensitivity(ini_default):
+    """Call isotopes with various capitalization versions."""
+    assert ini_default.iso["si-28"].name == "Si-28"
+    assert ini_default.iso["SI-28"].name == "Si-28"
+    assert ini_default.iso["sI-28"].name == "Si-28"
+    assert ini_default.iso["si28"].name == "Si-28"
+    assert ini_default.iso["28si"].name == "Si-28"
+    # list
+    assert ini_default.iso[["si-28", "28SI", "sI28"]].name == ["Si-28"] * 3

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -74,6 +74,14 @@ def test_get_all_isos(ini_default, ele):
     assert get_all_isos(ini_default, ele) == iso_list
 
 
+def test_iso_transform():
+    """Transform some example isotopes."""
+    iso_transform = iniabu.utilities.iso_transform
+    assert iso_transform("Si-28") == "Si-28"
+    assert iso_transform("28Si") == "Si-28"
+    assert iso_transform("Si28") == "Si-28"
+
+
 def test_linear_units_switch(ini_mf):
     """Ensure context manager works properly when unit switch required."""
     ini_log = iniabu.IniAbu(unit="num_log")

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -30,8 +30,8 @@ def test_proxy_list_index_error(ini_default):
         ini_default.ele[item]
     err_msg = err_info.value.args[0]
     assert (
-        err_msg
-        == f"Item {item} out of range. Must be in {ini_default._ele_dict.keys()}."
+        err_msg == f"Item {item.capitalize()} out of range. "
+        f"Must be in {ini_default._ele_dict.keys()}."
     )
 
 
@@ -76,7 +76,7 @@ def test_get_all_isos(ini_default, ele):
 
 def test_iso_transform():
     """Transform some example isotopes."""
-    iso_transform = iniabu.utilities.iso_transform
+    iso_transform = iniabu.utilities.item_formatter
     assert iso_transform("Si-28") == "Si-28"
     assert iso_transform("28Si") == "Si-28"
     assert iso_transform("Si28") == "Si-28"


### PR DESCRIPTION
- An isotope transformer was created that can take multiple isotope naming conventions and turn it into the `iniabu` standard naming scheme, e.g., Ti-46.
- The proxy list calls this isotope transformer (note, also with  elements).
- If no rule could be found that agrees with the non-standard naming,  it simply returns the originally passed value. Therefore, elements  will work fine and the proxy list handles any case in which a name  still does not exist.
- Added tests for the isotope transformer (simple ones)
- Added hypothesis test for the actual behavior that we want from an  isotope.

Still left to do:
- [x] Ensure that nothing is case sensitive, elements and isotopes
- [x] Add a section in the documentation that introduces the different possibilities for isotope naming

Closes #37 