### PR TITLE
BF: Test for issue #41 to reproduce the bug and fix

### DIFF
--- a/iniabu/utilities.py
+++ b/iniabu/utilities.py
@@ -50,7 +50,8 @@ class ProxyList:
 
     def __getitem__(self, idx):
         """Get an item from the proxy list."""
-        idx = idx.copy()  # do not alter user input
+        if hasattr(idx, "copy"):
+            idx = idx.copy()  # do not modify user input
         # turn idx into a list
         if isinstance(idx, tuple):
             idx = list(idx)

--- a/iniabu/utilities.py
+++ b/iniabu/utilities.py
@@ -50,6 +50,7 @@ class ProxyList:
 
     def __getitem__(self, idx):
         """Get an item from the proxy list."""
+        idx = idx.copy()  # do not alter user input
         # turn idx into a list
         if isinstance(idx, tuple):
             idx = list(idx)

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -249,3 +249,10 @@ def test_isotope_naming_case_sensitivity(ini_default):
     assert ini_default.iso["28si"].name == "Si-28"
     # list
     assert ini_default.iso[["si-28", "28SI", "sI28"]].name == ["Si-28"] * 3
+
+def test_isotope_naming_not_altered(ini_default):
+    """Ensure that input isotope list with alternative spelling is not altered."""
+    isos = ["46Ti", "47Ti"]
+    isos_exp = isos.copy()
+    _ = ini_default.iso[isos]
+    assert isos == isos_exp

--- a/tests/test_isotopes.py
+++ b/tests/test_isotopes.py
@@ -250,6 +250,7 @@ def test_isotope_naming_case_sensitivity(ini_default):
     # list
     assert ini_default.iso[["si-28", "28SI", "sI28"]].name == ["Si-28"] * 3
 
+
 def test_isotope_naming_not_altered(ini_default):
     """Ensure that input isotope list with alternative spelling is not altered."""
     isos = ["46Ti", "47Ti"]


### PR DESCRIPTION
- In the proxy list, the user input is now first copied before it is
  modified.
- Therefore, if the user does pass the input from a stored variable,
  this variable is not changed.

Closes #41 