### PR TITLE
Formatting update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@ repos:
     rev: 21.12b0
     hooks:
     -   id: black
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.0
+    hooks:
+      - id: pyupgrade
+        args: [ --py36-plus ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,6 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.12b0
     hooks:
     -   id: black

--- a/dev/asplund09/asplund09_to_dict.py
+++ b/dev/asplund09/asplund09_to_dict.py
@@ -10,12 +10,12 @@ import numpy as np
 from collections import OrderedDict
 
 isotopes = []
-with open("asplund09_isotopes.txt", "r") as f:
+with open("asplund09_isotopes.txt") as f:
     for line in f:
         isotopes.append(line.rstrip().split())
 
 elements = []
-with open("asplund09_elements.txt", "r") as f:
+with open("asplund09_elements.txt") as f:
     for line in f:
         elements.append(line.rstrip().split())
 
@@ -83,7 +83,7 @@ iso_entries = []
 for ele in ele_keys:
     for it, aa in enumerate(ele_dict[ele][1]):
         # iso key
-        iso_keys.append("{}-{}".format(ele, aa))
+        iso_keys.append(f"{ele}-{aa}")
         # entry
         tmp_entry = []
         # abundance

--- a/dev/lodders09/lodders09_to_dict.py
+++ b/dev/lodders09/lodders09_to_dict.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 
 # read in data file
 data_in = []
-with open("lodders09.dat", "r") as f:
+with open("lodders09.dat") as f:
     for line in f:
         data_in.append(line.rstrip().split())
 
@@ -30,7 +30,7 @@ iso_keys = []
 iso_entries = []
 
 for dat in data:
-    iso_keys.append("{}-{}".format(dat[1], dat[2]))
+    iso_keys.append(f"{dat[1]}-{dat[2]}")
     iso_entries.append([dat[3], dat[4]])
 
 iso_dict = OrderedDict(zip(iso_keys, iso_entries))

--- a/dev/nist_data/nist_data_to_dict.py
+++ b/dev/nist_data/nist_data_to_dict.py
@@ -22,7 +22,7 @@ for_all = True
 
 
 data_in = []
-with open(fname, "r") as f:
+with open(fname) as f:
     for line in f:
         data_in.append(line.rstrip())
 
@@ -56,7 +56,7 @@ def save_data(data):
         f.writelines("Z\tName\tA\tRel_Mass\tAbundance\n")
         for line in data:
             for item in line:
-                f.writelines("{}\t".format(item))
+                f.writelines(f"{item}\t")
             f.writelines("\n")
 
 
@@ -145,7 +145,7 @@ for element in ele_keys:
     # loop through A list
     for it, aa in enumerate(ele_dict[element][1]):
         # create the isotope name
-        iso_keys.append("{}-{}".format(element, aa))
+        iso_keys.append(f"{element}-{aa}")
         # stitch information together
         tmp_list = []
         tmp_list.append(ele_dict[element][2][it])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@ sys.path.append("../")
 
 project = "iniabu"
 author = "Reto Trappitsch"
-copyright = "2020, {}".format(author)
+copyright = f"2020, {author}"
 version = "1.0.1"
 release = version
 

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -166,38 +166,12 @@ Their GitHub site describes in detail
 how to use the formatter.
 There is really not much to configure.
 
-If you are using
-`PyCharm <https://www.jetbrains.com/pycharm/>`_
-as you editor,
-have a look at the
-`BlackConnect <https://plugins.jetbrains.com/plugin/14321-blackconnect>`_
-plugin.
-Make sure that no options are checked
-in the section ``Formatting options``.
-
-Alternatively, a ``nox`` session is implemented
-to automatically format code with ``black``.
-To do so,
-run the following command from your terminal:
-
-.. code-block:: console
-
-    $ nox -rs black
-
-As an alternative,
-the pre-commit hook can also be used
-to format your code using black.
-Check out section
+Formatting with black is implemented
+via a pre-commit hooks,
+see section
 :ref:`section_hooks`
 for more information.
-
-.. caution:: Make sure that you use
-  the correct version of black,
-  especially when formatting
-  differently from using ``nox``
-  or the pre-commit hook.
-  You can find the currently used version
-  in the `noxfile.py`.
+The hook file also specifies the used version of black.
 
 
 .. _section_linting:

--- a/docs/figures/int_norm.py
+++ b/docs/figures/int_norm.py
@@ -31,7 +31,7 @@ ax[0].plot(
     mew=2.0,
     linewidth=1,
     ms=8,
-    label="$\delta$-values",
+    label=r"$\delta$-values",
 )
 # define x limit
 xlim = (57.5, 64.5)
@@ -66,7 +66,7 @@ ax[1].plot(
     mew=2.0,
     linewidth=1,
     ms=8,
-    label="$\Delta$-values",
+    label=r"$\Delta$-values",
 )
 # horizontal line
 ax[1].hlines(0, xlim[0], xlim[1], linestyles="--", colors="k", linewidth=0.5)

--- a/iniabu/elements.py
+++ b/iniabu/elements.py
@@ -10,7 +10,7 @@ from . import data
 from .utilities import return_list_simplifier
 
 
-class Elements(object):
+class Elements:
     """Class representing the elements.
 
     This is mainly a list to easily interact with the `parent._ele_dict` dictionary.

--- a/iniabu/isotopes.py
+++ b/iniabu/isotopes.py
@@ -15,7 +15,7 @@ from .utilities import (
 )
 
 
-class Isotopes(object):
+class Isotopes:
     """Class representing the isotopes.
 
     This is mainly a list to easily interact with the `parent._iso_dict` dictionary.

--- a/iniabu/main.py
+++ b/iniabu/main.py
@@ -18,7 +18,7 @@ from .utilities import (
 )
 
 
-class IniAbu(object):
+class IniAbu:
     """Initialize the IniAbu class.
 
     By default, the ``lodders09`` database is read in. Available databases are:
@@ -864,4 +864,4 @@ class IniAbu(object):
         """
         isotopes = self.ele[element].iso_a
         abus = self.ele[element].iso_abu_rel
-        return "{}-{}".format(element, isotopes[abus.argmax()])
+        return f"{element}-{isotopes[abus.argmax()]}"

--- a/iniabu/utilities.py
+++ b/iniabu/utilities.py
@@ -106,7 +106,7 @@ def get_all_stable_isos(ini, ele):
     :rtype: list(str)
     """
     isotopes = ini.ele[ele].iso_a
-    ret_val = ["{}-{}".format(ele, isotope) for isotope in isotopes]
+    ret_val = [f"{ele}-{isotope}" for isotope in isotopes]
     return ret_val
 
 
@@ -186,7 +186,7 @@ def make_iso_dict(element_dict):
     iso_entries = []
     for key in element_dict.keys():
         for it, iso in enumerate(element_dict[key][1]):
-            iso_keys.append("{}-{}".format(key, iso))
+            iso_keys.append(f"{key}-{iso}")
             rel_abu = element_dict[key][2][it]
             ss_abu = element_dict[key][3][it]
             iso_entries.append([rel_abu, ss_abu])

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,15 +12,6 @@ python_main = "3.10"
 
 
 @nox.session(python=python_main)
-def black(session):
-    """Autoformat all python files with black."""
-    args = session.posargs or locations
-    session.install("--upgrade", "pip")
-    session.install("black==20.8b1")
-    session.run("black", *args)
-
-
-@nox.session(python=python_main)
 def build(session):
     """Pack iniabu for release on PyPi."""
     session.install("flit")


### PR DESCRIPTION
- Update black version to 21.12b0
- Run python 3.6+ auto format (https://github.com/asottile/pyupgrade)
- Update docs to use black only with `pre-commit`, no more `nox`