### PR TITLE
New years cleanup

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,7 +6,7 @@ flake8-bugbear
 flake8-docstrings
 flake8-import-order
 hypothesis
-pytest
+pytest>=6.0
 pytest-cov
 pytest-mock
 pytest-sugar

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@ sys.path.append("../")
 
 project = "iniabu"
 author = "Reto Trappitsch"
-copyright = f"2020, {author}"
+copyright = f"2020-2022, {author}"
 version = "1.0.1"
 release = version
 

--- a/iniabu/__init__.py
+++ b/iniabu/__init__.py
@@ -21,4 +21,4 @@ __author__ = "Reto Trappitsch"
 __email__ = "reto@galactic-forensics.space"
 
 __license__ = "GPLv2"
-__copyright__ = "Copyright (c) 2020, Reto Trappitsch"
+__copyright__ = "Copyright (c) 2020-2022, Reto Trappitsch"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ doc = [
     "sphinx_rtd_theme"
 ]
 test = [
-    "pytest",
+    "pytest>=6.0",
     "pytest-cov",
     "pytest-mock",
     "pytest-sugar"
@@ -51,3 +51,8 @@ Documentation = "https://iniabu.readthedocs.io"
 
 [tool.flit.sdist]
 exclude = ["dev/"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--cov=iniabu -v"
+testpaths = "tests"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-testpaths =
-    tests
-addopts =
-    --cov=iniabu
-    -v


### PR DESCRIPTION
- Update copyright
- Move `pytest` configuration into `pyproject.toml`