### PR TITLE
Bump version: 1.0.1 → 1.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.1.0
 commit = True
 tag = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ sys.path.append("../")
 project = "iniabu"
 author = "Reto Trappitsch"
 copyright = f"2020-2022, {author}"
-version = "1.0.1"
+version = "1.1.0"
 release = version
 
 

--- a/iniabu/__init__.py
+++ b/iniabu/__init__.py
@@ -8,7 +8,7 @@ inimf = IniAbu(unit="mass_fraction")
 inilog = IniAbu(unit="num_log")
 
 # Package information
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 __title__ = "iniabu"
 __description__ = (


### PR DESCRIPTION
Changes since v1.0.1:
- Allow for alternative isotope names #39 
- Support and tests for Python 3.10 #45 
- Support to return isotope masses for unstable isotopes including full NIST list #46 