### PR TITLE
Skip missing interpreters in `nox`

### DIFF
--- a/.github/workflows/package_testing.yml
+++ b/.github/workflows/package_testing.yml
@@ -32,7 +32,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
     - name: Run nox
-      run: nox
+      run: nox --no-error-on-missing-interpreters
     - name: Re-run coverage and push to coveralls
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
`nox` workflow seems unstable at this point, therefore simply use my existing workflow and skip failure of tests when python versions are missing. This is currently still matrixed in inside the GitHub action.
