### PR TITLE
Update supported python to 3.13, minimum version 3.9

### DIFF
--- a/.github/workflows/package_testing.yml
+++ b/.github/workflows/package_testing.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  MAIN_PYTHON_VERSION: "3.12"
+  MAIN_PYTHON_VERSION: "3.13"
 
 jobs:
   # Build and test
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -25,10 +25,15 @@ coverage==7.6.1
 docutils==0.20.1
     # via sphinx
     # via sphinx-rtd-theme
+exceptiongroup==1.2.2
+    # via hypothesis
+    # via pytest
 hypothesis==6.111.2
 idna==3.8
     # via requests
 imagesize==1.4.1
+    # via sphinx
+importlib-metadata==8.5.0
     # via sphinx
 iniconfig==2.0.0
     # via pytest
@@ -36,7 +41,7 @@ jinja2==3.1.4
     # via sphinx
 markupsafe==2.1.5
     # via jinja2
-numpy==2.1.0
+numpy==2.0.2
     # via iniabu
 packaging==24.1
     # via pytest
@@ -76,6 +81,12 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
+tomli==2.0.2
+    # via coverage
+    # via pytest
+    # via sphinx
 urllib3==2.2.2
     # via requests
 xdoctest==1.2.0
+zipp==3.20.2
+    # via importlib-metadata

--- a/requirements.lock
+++ b/requirements.lock
@@ -25,11 +25,13 @@ idna==3.8
     # via requests
 imagesize==1.4.1
     # via sphinx
+importlib-metadata==8.5.0
+    # via sphinx
 jinja2==3.1.4
     # via sphinx
 markupsafe==2.1.5
     # via jinja2
-numpy==2.1.0
+numpy==2.0.2
     # via iniabu
 packaging==24.1
     # via sphinx
@@ -59,5 +61,9 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
+tomli==2.0.2
+    # via sphinx
 urllib3==2.2.2
     # via requests
+zipp==3.20.2
+    # via importlib-metadata


### PR DESCRIPTION
This PR updates the supported python version to 3.13, with a minimum version of 3.9