### PR TITLE
Update supported python to 3.13, minimum version 3.9

### DIFF
--- a/.github/workflows/package_testing.yml
+++ b/.github/workflows/package_testing.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  MAIN_PYTHON_VERSION: "3.12"
+  MAIN_PYTHON_VERSION: "3.13"
 
 jobs:
   # Build and test
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4


### PR DESCRIPTION
This PR updates the supported python version to 3.13, with a minimum version of 3.9