### PR TITLE
BF for non-standard iso name in iso_ratio with mass_fraction=True

### DIFF
--- a/src/iniabu/main.py
+++ b/src/iniabu/main.py
@@ -10,6 +10,7 @@ from . import utilities
 from .elements import Elements
 from .isotopes import Isotopes
 from .utilities import (
+    item_formatter,
     linear_units,
     ProxyList,
     return_as_ndarray,
@@ -886,8 +887,12 @@ class IniAbu:
         # correct if mass_fraction is true and not in mass_fraction notation already
         if mass_fraction and self.unit != "mass_fraction":
             # turn into list if necessary
-            nominator = return_string_as_list(nominator)
-            denominator = return_string_as_list(denominator)
+            nominator = [
+                item_formatter(iso) for iso in return_string_as_list(nominator)
+            ]
+            denominator = [
+                item_formatter(iso) for iso in return_string_as_list(denominator)
+            ]
             # get masses
             nominator_masses = [data.isotopes_mass[iso] for iso in nominator]
             denominator_masses = [data.isotopes_mass[iso] for iso in denominator]

--- a/tests/test_main_ratios.py
+++ b/tests/test_main_ratios.py
@@ -320,3 +320,9 @@ def test_nist_ratio_isos_isos(ini_nist):
         ]
     )
     np.testing.assert_equal(ini_nist.iso_ratio(nom, denom), expected)
+
+
+def test_mf_non_standard_isonames(ini_default):
+    """BF: Mass fraction for non-standard isotope names."""
+    isos = ["28Si", "29Si"]
+    _ = ini_default.iso_ratio(*isos, mass_fraction=True)


### PR DESCRIPTION
Running `ini.iso_ratio` with `mass_fraction=True` and non-standardized isotope names resulted in a key error.
Now the isotope names for this are passed through the formatter to create a standardized name before 
doing the dictionary lookup.

